### PR TITLE
fix: zero initialize fields when using default constructor.

### DIFF
--- a/includes/eeros/math/Matrix.hpp
+++ b/includes/eeros/math/Matrix.hpp
@@ -36,7 +36,7 @@ namespace eeros {
 			
 			/********** Constructors **********/
 			
-			Matrix() { }
+			Matrix() = default;
 			
 			Matrix(const T v) {
 				(*this) = v;
@@ -851,7 +851,7 @@ namespace eeros {
 			}
 			
 		protected:
-			T value[M * N];
+			T value[M * N]{};
 			
 		}; // END class Matrix
 		
@@ -947,7 +947,7 @@ namespace eeros {
 			
 			using value_type = T;
 			
-			Matrix() { }
+			Matrix() = default;
 			
 			Matrix(const T v) { value = v; }
 			
@@ -1018,7 +1018,7 @@ namespace eeros {
 			}
 			
 		protected:
-			T value;
+			T value{};
 		};
 		
 	} // END namespace math


### PR DESCRIPTION
# Issue
When a Matrix is instantiated with the default constructor (Vector3 vec{}), we assume that all fields are zero initialized. For example, if a double Vector3 is instantiated as shown above, we assume to get a vector (Matrix/Vector3 instance) with three zero double values. With the current implementation, this must not be the case and the double values can have any random values.


# Changes
* use default constructor instead of empty constructor.
* call default initializer on field types when class is instantiated.
