### PR TITLE
Make thread safe

### DIFF
--- a/examples/controlSystem/BlockTest2.cpp
+++ b/examples/controlSystem/BlockTest2.cpp
@@ -35,8 +35,7 @@ public:
 
 class ControlSystem {
 public:
-	ControlSystem(TimeDomain& td) : g(10), p("out"), td(td) {
-		c = Constant<>(0.568);
+	ControlSystem(TimeDomain& td) : g(10), p("out"), c(0.568), td(td) {
 		c.getOut().getSignal().setName("constant output");
 		g.getOut().getSignal().setName("gain output");
 		g.getIn().connect(c.getOut());

--- a/includes/eeros/control/Constant.hpp
+++ b/includes/eeros/control/Constant.hpp
@@ -2,6 +2,7 @@
 #define ORG_EEROS_CONTROL_CONSTANT_HPP_
 
 #include <type_traits>
+#include <mutex>
 #include <eeros/control/Block1o.hpp>
 #include <eeros/core/System.hpp>
 
@@ -18,15 +19,17 @@ namespace eeros {
 			Constant(T v) : value(v) { }
 			
 			virtual void run() {
+				std::lock_guard<std::mutex> lock(mtx);
 				this->out.getSignal().setValue(value);
 				this->out.getSignal().setTimestamp(System::getTimeNs());
 			}
 			
 			virtual void setValue(T newValue) {
+				std::lock_guard<std::mutex> lock(mtx);
 				value = newValue;
 			}
 
-			virtual T getValue() {
+			virtual T getValue () const {
 				return value;
 			}
 
@@ -35,6 +38,7 @@ namespace eeros {
 
 		protected:
 			T value;
+			std::mutex mtx;
 			
 		private:
 			template <typename S> typename std::enable_if<std::is_integral<S>::value>::type _clear() {


### PR DESCRIPTION
The constant block was not thread safe. When calling the method setValue from another thread, such as the Sequencer or the Safety System, the assignment value = newValue could have been interrupted by the run method of the block, which would lead to a partially changed vector.