### PR TITLE
Simplify creation of sequences and steps

### DIFF
--- a/examples/hal/HalTest1.hpp
+++ b/examples/hal/HalTest1.hpp
@@ -69,7 +69,7 @@ public:
 
 class StepDigOut : public Step {
 public:
-	StepDigOut(std::string name, Sequencer& sequencer, BaseSequence* caller, MyControlSystem& cs) : Step(name, sequencer, caller), cs(cs) { }
+	StepDigOut(std::string name, Sequence* caller, MyControlSystem& cs) : Step(name, caller), cs(cs) { }
 	int operator() (bool val) {state = val; return start();}
 	int action() {cs.c0.setValue(state);}
 	bool state;
@@ -78,7 +78,7 @@ public:
 
 class StepAnalogOut : public Step {
 public:
-	StepAnalogOut(std::string name, Sequencer& sequencer, BaseSequence* caller, MyControlSystem& cs) : Step(name, sequencer, caller), cs(cs) { }
+	StepAnalogOut(std::string name, Sequence* caller, MyControlSystem& cs) : Step(name, caller), cs(cs) { }
 	int operator() (bool val) {state = val; return start();}
 	int action() {
 		if (state) {
@@ -95,8 +95,8 @@ public:
 
 class SeqDigital : public Sequence {
 public:
-	SeqDigital(std::string name, Sequencer& sequencer, BaseSequence* caller, MyControlSystem& cs) : 
-		Sequence(name, sequencer, caller, false), stepDigOut("step dig out", seq, this, cs), wait("waiting time digital", seq, this) { }
+	SeqDigital(std::string name, Sequence* caller, MyControlSystem& cs) : 
+		Sequence(name, caller, false), stepDigOut("step dig out", this, cs), wait("waiting time digital", this) { }
 	int action() {
 		bool toggle;
 		while (Sequencer::running) {
@@ -112,8 +112,8 @@ private:
 
 class SeqAnalog : public Sequence {
 public:
-	SeqAnalog(std::string name, Sequencer& sequencer, BaseSequence* caller, MyControlSystem& cs) : 
-		Sequence(name, sequencer, caller, false), stepAnalogOut("step analog out", seq, this, cs), wait("waiting time analog", seq, this) { }
+	SeqAnalog(std::string name, Sequence* caller, MyControlSystem& cs) : 
+		Sequence(name, caller, false), stepAnalogOut("step analog out", this, cs), wait("waiting time analog", this) { }
 	int action() {
 		bool toggle;
 		while (Sequencer::running) {
@@ -129,7 +129,7 @@ private:
 
 class MyMainSequence : public Sequence {
 public:
-	MyMainSequence(Sequencer& seq, MyControlSystem& cs) : Sequence("main", seq), cs(cs), seqDigital("seq dig out", seq, this, cs), seqAnalog("seq analog out", seq, this, cs) { }
+	MyMainSequence(Sequencer& seq, MyControlSystem& cs) : Sequence("main", seq), cs(cs), seqDigital("seq dig out", this, cs), seqAnalog("seq analog out", this, cs) { }
 	
 	int action() {
 		seqDigital();

--- a/examples/hal/HalTest2.hpp
+++ b/examples/hal/HalTest2.hpp
@@ -64,7 +64,7 @@ public:
 
 class MyMainSequence : public Sequence {
 public:
-	MyMainSequence(Sequencer& sequencer, MyControlSystem& controlSys) : Sequence("main", sequencer), wait("waiting time", seq, this), controlSys(controlSys) { }
+	MyMainSequence(Sequencer& sequencer, MyControlSystem& controlSys) : Sequence("main", sequencer), wait("waiting time", this), controlSys(controlSys) { }
 	
 	int action() {
 		// set PWM frequency here for example or in main of application

--- a/examples/mockRobotExample/MockRobotSequencer.hpp
+++ b/examples/mockRobotExample/MockRobotSequencer.hpp
@@ -13,7 +13,7 @@ using namespace eeros::logger;
 
 class MoveUp : public Step {
 public:
-	MoveUp(std::string name, Sequencer& sequencer, BaseSequence* caller, MockRobotControlSystem& cs) : Step(name, sequencer, caller), cs(cs) { }
+	MoveUp(std::string name, Sequence* caller, MockRobotControlSystem& cs) : Step(name, caller), cs(cs) { }
 	int action() {
 		cs.setpointX.setValue(0.7);
 		cs.setpointY.setValue(0.3);
@@ -25,7 +25,7 @@ private:
 
 class MoveDown : public Step {
 public:
-	MoveDown(std::string name, Sequencer& sequencer, BaseSequence* caller, MockRobotControlSystem& cs) : Step(name, sequencer, caller), cs(cs) { }
+	MoveDown(std::string name, Sequence* caller, MockRobotControlSystem& cs) : Step(name, caller), cs(cs) { }
 	int action() {
 		cs.setpointX.setValue(-0.6);
 		cs.setpointY.setValue(-0.3);
@@ -37,7 +37,7 @@ private:
 
 class UpAndDownSequence : public Sequence {
 public:
-	UpAndDownSequence(std::string name, Sequencer& seq, MockRobotControlSystem& cs) : Sequence(name, seq), cs(cs), moveUp("move up", seq, this, cs), moveDown("move down", seq, this, cs) { }
+	UpAndDownSequence(std::string name, Sequencer& seq, MockRobotControlSystem& cs) : Sequence(name, seq), cs(cs), moveUp("move up", this, cs), moveDown("move down", this, cs) { }
 		
 	int action() {
 		while (Sequencer::running) {

--- a/examples/sequencer/SequencerTest1.cpp
+++ b/examples/sequencer/SequencerTest1.cpp
@@ -10,7 +10,7 @@ using namespace eeros::logger;
 
 class ExceptionSeq : public Sequence {
 public:
-	ExceptionSeq(std::string name, Sequencer& seq, BaseSequence* caller) : Sequence(name, seq, caller, true), wait("wait", seq, this) { }
+	ExceptionSeq(std::string name, Sequence* caller) : Sequence(name, caller, true), wait("wait", this) { }
 	int action() {wait(3);}
 private:
 	Wait wait;
@@ -18,7 +18,7 @@ private:
 
 class MainSequence : public Sequence {
 public:
-	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), stepA("step A", seq, this), eSeq("exception sequence", seq, this) { 
+	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), stepA("step A", this), eSeq("exception sequence", this) { 
 		setTimeoutTime(2.5);
 		setTimeoutExceptionSequence(eSeq);
 // 		setTimeoutBehavior(SequenceProp::resume);

--- a/examples/sequencer/SequencerTest2.cpp
+++ b/examples/sequencer/SequencerTest2.cpp
@@ -11,7 +11,7 @@ using namespace eeros::logger;
 
 class ExceptionSeq : public Sequence {
 public:
-	ExceptionSeq(std::string name, Sequencer& seq, BaseSequence* caller) : Sequence(name, seq, caller, true), wait("wait", seq, this) { }
+	ExceptionSeq(std::string name, Sequence* caller) : Sequence(name, caller, true), wait("wait", this) { }
 	int action() {wait(3);}
 private:
 	Wait wait;
@@ -19,7 +19,7 @@ private:
 
 class SequenceB : public Sequence {
 public:
-	SequenceB(std::string name, Sequencer& seq, BaseSequence* caller) : Sequence(name, seq, caller, false), stepB("step B", seq, this), eSeq("exception sequence", seq, this) { 
+	SequenceB(std::string name, Sequencer& seq, Sequence* caller) : Sequence(name, caller, false), stepB("step B", this), eSeq("exception sequence", this) { 
 		setTimeoutTime(2.5);
 		setTimeoutExceptionSequence(*(seq.getSequenceByName("exception sequence")));
 		setTimeoutBehavior(SequenceProp::abort);
@@ -34,7 +34,7 @@ private:
 
 class MainSequence : public Sequence {
 public:
-	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), seqB("seq B", seq, this), stepA("step A", seq, this) { }
+	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), seqB("seq B", seq, this), stepA("step A", this) { }
 		
 	int action() {
 		for (int i = 0; i < 3; i++) stepA(2);

--- a/examples/sequencer/SequencerTest3.cpp
+++ b/examples/sequencer/SequencerTest3.cpp
@@ -11,7 +11,7 @@ using namespace eeros::logger;
 
 class SequenceB : public Sequence {
 public:
-	SequenceB(std::string name, Sequencer& seq, BaseSequence* caller) : Sequence(name, seq, caller, true), stepB("step B", seq, this) { }
+	SequenceB(std::string name, Sequence* caller) : Sequence(name, caller, true), stepB("step B", this) { }
 	int action() {
 		for (int i = 0; i < 5; i++) stepB(1);
 	}
@@ -21,7 +21,7 @@ private:
 
 class SequenceA : public Sequence {
 public:
-	SequenceA(std::string name, Sequencer& seq, BaseSequence* caller) : Sequence(name, seq, caller, true), stepA("step A", seq, this), seqB("sequence B", seq, this) { 
+	SequenceA(std::string name, Sequence* caller) : Sequence(name, caller, true), stepA("step A", this), seqB("sequence B", this) { 
 		setTimeoutTime(3.5);
 		setTimeoutBehavior(SequenceProp::abort);
 	}
@@ -39,7 +39,7 @@ private:
 
 class MainSequence : public Sequence {
 public:
-	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), seqA("sequence A", seq, this) { }
+	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), seqA("sequence A", this) { }
 		
 	int action() {
 		seqA();

--- a/examples/sequencer/SequencerTest4.cpp
+++ b/examples/sequencer/SequencerTest4.cpp
@@ -13,7 +13,7 @@ int count = 0;
 
 class ExceptionSeq : public Sequence {
 public:
-	ExceptionSeq(std::string name, Sequencer& seq, BaseSequence* caller) : Sequence(name, seq, caller, true), wait("wait E", seq, this) { }
+	ExceptionSeq(std::string name, Sequence* caller) : Sequence(name, caller, true), wait("wait E", this) { }
 	int action() {count = 0; wait(0.5);}
 private:
 	Wait wait;
@@ -25,7 +25,7 @@ class MyCondition : public Condition {
 
 class MainSequence : public Sequence {
 public:
-	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), stepA("step A", seq, this), eSeq("exception sequence", seq, this), m("myMonitor", this, cond, SequenceProp::resume, &eSeq) { 
+	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), stepA("step A", this), eSeq("exception sequence", this), m("myMonitor", this, cond, SequenceProp::resume, &eSeq) { 
 		setTimeoutTime(7.0);
 		setTimeoutBehavior(SequenceProp::abort);
 		addMonitor(&m);

--- a/examples/sequencer/SequencerTest5.cpp
+++ b/examples/sequencer/SequencerTest5.cpp
@@ -17,7 +17,7 @@ class MyCondition : public Condition {
 
 class SequenceB : public Sequence {
 public:
-	SequenceB(std::string name, Sequencer& seq, BaseSequence* caller, Monitor& m) : Sequence(name, seq, caller, false), stepB("step B", seq, this), m(m) { 
+	SequenceB(std::string name, Sequence* caller, Monitor& m) : Sequence(name, caller, false), stepB("step B", this), m(m) { 
 		addMonitor(&m);
 	}
 	int action() {
@@ -30,7 +30,7 @@ private:
 
 class MainSequence : public Sequence {
 public:
-	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), m("myMonitor", this, cond, SequenceProp::abort), seqB("sequence B", seq, this, m), stepA("step A", seq, this) { 
+	MainSequence(std::string name, Sequencer& seq) : Sequence(name, seq), m("myMonitor", this, cond, SequenceProp::abort), seqB("sequence B", this, m), stepA("step A", this) { 
 		addMonitor(&m);
 	}
 		

--- a/examples/simpleMotorController/MainSequence.hpp
+++ b/examples/simpleMotorController/MainSequence.hpp
@@ -15,7 +15,7 @@ using namespace eeros::logger;
 
 class Move : public Step {
 public:
-	Move(std::string name, Sequencer& sequencer, BaseSequence* caller, MyControlSystem& cs) : Step(name, sequencer, caller), cs(cs) { }
+	Move(std::string name, Sequence* caller, MyControlSystem& cs) : Step(name, caller), cs(cs) { }
 	int operator() (double pos) {this->pos = pos; return start();}
 	int action() {
 		cs.setpoint.setValue(pos);
@@ -27,7 +27,7 @@ public:
 class MainSequence : public Sequence {
 public:
 	MainSequence(std::string name, Sequencer& seq, SafetySystem& safetySys, MySafetyProperties& safetyProp, MyControlSystem& cs, double angle) : 
-					Sequence(name, seq), safetySys(safetySys), safetyProp(safetyProp), angle(angle), controlSys(cs), move("move", seq, this, cs) {
+					Sequence(name, seq), safetySys(safetySys), safetyProp(safetyProp), angle(angle), controlSys(cs), move("move", this, cs) {
 		log.info() << "Sequence created: " << name;
 	}
 	int action() {

--- a/includes/eeros/sequencer/BaseSequence.hpp
+++ b/includes/eeros/sequencer/BaseSequence.hpp
@@ -27,8 +27,10 @@ namespace eeros {
 		class BaseSequence {	
 			friend class Monitor;
 			friend class Sequencer;
+			friend class Sequence;
 		public:
 			BaseSequence(Sequencer& seq, BaseSequence* caller, bool blocking);
+			BaseSequence(BaseSequence* caller, bool blocking);
 			virtual ~BaseSequence();
 			
 			virtual int start() = 0;

--- a/includes/eeros/sequencer/Sequence.hpp
+++ b/includes/eeros/sequencer/Sequence.hpp
@@ -14,7 +14,7 @@ namespace eeros {
 			friend class Sequencer;
 		public:
 			Sequence(std::string name, Sequencer& seq);	// only for mainSequence
-			Sequence(std::string name, Sequencer& seq, BaseSequence* caller, bool blocking);
+			Sequence(std::string name, BaseSequence* caller, bool blocking);
 			virtual ~Sequence();
 			
  			virtual int operator() () {return start();}	// this operator can be overloaded in the derived sequence
@@ -32,6 +32,7 @@ namespace eeros {
 			void waitAndTerminate();
 			
 		private:
+			Sequence(std::string name, Sequencer& seq, BaseSequence* caller, bool blocking);
 			bool running = true, go = false, done = true;
 			std::thread* t = nullptr;
 			void run();

--- a/includes/eeros/sequencer/Step.hpp
+++ b/includes/eeros/sequencer/Step.hpp
@@ -8,7 +8,7 @@ namespace eeros {
 
 		class Step : public BaseSequence {
 		public:
-			Step(std::string name, Sequencer& seq, BaseSequence* caller) : BaseSequence(seq, caller, true) {this->name = name;}
+			Step(std::string name, BaseSequence* caller) : BaseSequence(caller, true) {this->name = name;}
 			virtual ~Step() { };
 			
 			virtual int operator() () {return start();}	// this operator can be overloaded in the derived sequence

--- a/includes/eeros/sequencer/Wait.hpp
+++ b/includes/eeros/sequencer/Wait.hpp
@@ -8,7 +8,7 @@ namespace eeros {
 
 		class Wait : public Step {
 		public:
-			Wait(std::string name, Sequencer& seq, BaseSequence* caller) : Step(name, seq, caller) { }
+			Wait(std::string name, BaseSequence* caller) : Step(name, caller) { }
 			virtual ~Wait() { };
 			
 			int operator() (double waitingTime) {this->waitingTime = waitingTime; return start();}

--- a/src/sequencer/BaseSequence.cpp
+++ b/src/sequencer/BaseSequence.cpp
@@ -6,6 +6,8 @@
 namespace eeros {
 	namespace sequencer {
 
+		BaseSequence::BaseSequence(BaseSequence* caller, bool blocking) : BaseSequence(caller->seq, caller, blocking) { }
+		
 		BaseSequence::BaseSequence(Sequencer& seq, BaseSequence* caller, bool blocking) : 
 			seq(seq), caller(caller), monitorTimeout("timeout", this, conditionTimeout, SequenceProp::abort), monitorAbort("abort", this, conditionAbort, SequenceProp::abort),
 			state(SequenceState::idle), blocking(blocking), pollingTime(100), log('X')

--- a/src/sequencer/Sequence.cpp
+++ b/src/sequencer/Sequence.cpp
@@ -9,6 +9,8 @@ using namespace eeros::sequencer;
 
 Sequence::Sequence(std::string name, Sequencer& seq) : Sequence(name, seq, nullptr, false) { }
 
+Sequence::Sequence(std::string name, BaseSequence* caller, bool blocking) : Sequence(name, caller->seq, caller, blocking) { }
+
 Sequence::Sequence(std::string name, Sequencer& seq, BaseSequence* caller, bool blocking) : BaseSequence(seq, caller, blocking) {
 	static int sequenceCount;
 	setId(sequenceCount++);	//TODO check how many sequence objects of this type are allowed. Maybe singleton.


### PR DESCRIPTION
When creating sequences or steps, it is no longer necessary to pass a reference to the sequencer. The sequencer instance is taken from the caller of this sequence or step.