### PR TITLE
Upgrade libucl to latest version

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(libucl-download NONE)
 include(ExternalProject)
 ExternalProject_Add(libucl
   GIT_REPOSITORY    https://github.com/eeros-project/libucl.git
-  GIT_TAG           master
+  GIT_TAG           83fcf3f33c9992aa8823f6267ecc2a070b02c79d
   SOURCE_DIR        "${EEROS_BINARY_DIR}/libucl-src"
   BINARY_DIR        "${EEROS_BINARY_DIR}/libucl-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Using commit hash instead of master branch to fix version.

All unit tests pass with the latest version. However there is no easy way to check what other side effects this upgrade can lead to. So, should we merge this now or right after the next release?