### PR TITLE
Enable examples installation

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(${EEROS_SOURCE_DIR}/includes ${EEROS_BINARY_DIR})
 
+set(INSTALL_EXAMPLES TRUE CACHE BOOL "Install EEROS examples if TRUE") # default if not set in CACHE.
+
 add_subdirectory(config)
 add_subdirectory(block)
 add_subdirectory(task)
@@ -12,3 +14,4 @@ add_subdirectory(sequencer)
 add_subdirectory(socket)
 add_subdirectory(devel)
 add_subdirectory(system)
+

--- a/examples/block/CMakeLists.txt
+++ b/examples/block/CMakeLists.txt
@@ -1,31 +1,50 @@
 add_custom_command(OUTPUT copyPathFile POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/block/path.txt" "${EEROS_BINARY_DIR}/examples/block")
 
+set(targets "")
+
 add_executable(blockTest BlockTest.cpp)
 target_link_libraries(blockTest eeros ${EEROS_LIBS})
+list(APPEND targets blockTest)
 
 add_executable(mouseTest MouseTest.cpp)
 target_link_libraries(mouseTest eeros ${EEROS_LIBS})
+list(APPEND targets mouseTest)
 
 add_executable(xBoxTest XBoxTest.cpp)
 target_link_libraries(xBoxTest eeros ${EEROS_LIBS})
+list(APPEND targets xBoxTest)
 
 add_executable(keyboardTest KeyboardTest.cpp)
 target_link_libraries(keyboardTest eeros ${EEROS_LIBS})
+list(APPEND targets keyboardTest)
 
 add_executable(traceTest TraceTest.cpp)
 target_link_libraries(traceTest eeros ${EEROS_LIBS})
+list(APPEND targets traceTest)
 
 add_executable(spaceNavigatorTest SpaceNavigatorTest.cpp)
 target_link_libraries(spaceNavigatorTest eeros ${EEROS_LIBS})
+list(APPEND targets spaceNavigatorTest)
 
 add_executable(transitionBlockTest1 TransitionBlockTest.cpp)
 target_link_libraries(transitionBlockTest1 eeros ${EEROS_LIBS})
+list(APPEND targets transitionBlockTest1)
 
 add_executable(pathPlannerTest1 PathPlannerTest1.cpp)
 target_link_libraries(pathPlannerTest1 eeros ${EEROS_LIBS})
+list(APPEND targets pathPlannerTest1)
 
 add_executable(pathPlannerTest2 PathPlannerTest2.cpp)
 target_link_libraries(pathPlannerTest2 eeros ${EEROS_LIBS})
+list(APPEND targets pathPlannerTest2)
 
 add_executable(pathPlannerTest3 PathPlannerTest3.cpp copyPathFile)
 target_link_libraries(pathPlannerTest3 eeros ${EEROS_LIBS})
+list(APPEND targets pathPlannerTest3)
+
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS ${targets} RUNTIME DESTINATION examples/block)
+  install(FILES ${EEROS_BINARY_DIR}/examples/block/path.txt DESTINATION examples/block)
+endif()
+

--- a/examples/can/CMakeLists.txt
+++ b/examples/can/CMakeLists.txt
@@ -1,5 +1,9 @@
 if (canopenlib_FOUND)
 	add_executable(canExample CanExample.cpp)
 	target_link_libraries(canExample eeros canopenlib ${EEROS_LIBS})
+
+  if(INSTALL_EXAMPLES)
+    install(TARGETS canExample RUNTIME DESTINATION examples/can)
+  endif()
 endif()
 

--- a/examples/config/CMakeLists.txt
+++ b/examples/config/CMakeLists.txt
@@ -3,3 +3,8 @@ add_custom_command(OUTPUT copyConfig POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy
 add_executable(configExample ConfigExample.cpp copyConfig)
 target_link_libraries(configExample eeros ${EEROS_LIBS})
 
+if(INSTALL_EXAMPLES)
+  install(TARGETS configExample RUNTIME DESTINATION examples/config)
+  install(FILES ${EEROS_BINARY_DIR}/examples/config/config.txt DESTINATION examples/config)
+endif()
+

--- a/examples/devel/CMakeLists.txt
+++ b/examples/devel/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(multithreading multithreading.cpp)
 target_link_libraries(multithreading eeros ${EEROS_LIBS})
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS multithreading RUNTIME DESTINATION examples/devel)
+endif()
+

--- a/examples/hal/CMakeLists.txt
+++ b/examples/hal/CMakeLists.txt
@@ -1,9 +1,27 @@
+set(files "")
 add_custom_command(OUTPUT copyHalTest1Config POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/hal/HalTest1Config.json" "${EEROS_BINARY_DIR}/examples/hal")
+list(APPEND files ${EEROS_BINARY_DIR}/examples/hal/HalTest1Config.json)
+
 add_custom_command(OUTPUT copyHalTest2CConfig POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/hal/HalTest2ConfigComedi.json" "${EEROS_BINARY_DIR}/examples/hal")
+list(APPEND files ${EEROS_BINARY_DIR}/examples/hal/HalTest2ConfigComedi.json)
+
 add_custom_command(OUTPUT copyHalTest2FConfig POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/hal/HalTest2ConfigFlink.json" "${EEROS_BINARY_DIR}/examples/hal")
+list(APPEND files ${EEROS_BINARY_DIR}/examples/hal/HalTest2ConfigFlink.json)
+
+
+set(targets "")
 
 add_executable(halTest1 HalTest1.cpp copyHalTest1Config)
 target_link_libraries(halTest1 eeros ${EEROS_LIBS})
+list(APPEND targets halTest1)
 
 add_executable(halTest2 HalTest2.cpp copyHalTest2CConfig copyHalTest2FConfig)
 target_link_libraries(halTest2 eeros ${EEROS_LIBS})
+list(APPEND targets halTest2)
+
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS ${targets} RUNTIME DESTINATION examples/hal)
+  install(FILES ${files} DESTINATION examples/hal)
+endif()
+

--- a/examples/logger/CMakeLists.txt
+++ b/examples/logger/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(loggerTest LoggerTest.cpp)
 target_link_libraries(loggerTest eeros ${EEROS_LIBS})
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS loggerTest RUNTIME DESTINATION examples/logger)
+endif()
+

--- a/examples/ros/CMakeLists.txt
+++ b/examples/ros/CMakeLists.txt
@@ -1,17 +1,31 @@
 
 if (roslib_FOUND AND USE_ROS)
+  set(targets "")
+
 	add_executable(rosNodeTalker RosNodeTalker.cpp)
 	target_link_libraries(rosNodeTalker eeros ${EEROS_LIBS})
+  list(APPEND targets rosNodeTalker)
 	
-	add_custom_command(OUTPUT copyHalTest2Config POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/ros/RosTest2Config.json" "${EEROS_BINARY_DIR}/examples/ros")
-	add_custom_command(OUTPUT copyHalTest3Config POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/ros/HalConfigRos.json" "${EEROS_BINARY_DIR}/examples/ros")
+  set(files "")	
+  add_custom_command(OUTPUT copyHalTest2Config POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/ros/RosTest2Config.json" "${EEROS_BINARY_DIR}/examples/ros")
+  list(APPEND files ${EEROS_BINARY_DIR}/examples/ros/RosTest2Config.json)	
+  add_custom_command(OUTPUT copyHalTest3Config POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/ros/HalConfigRos.json" "${EEROS_BINARY_DIR}/examples/ros")
+  list(APPEND files ${EEROS_BINARY_DIR}/examples/ros/HalConfigRos.json)
 
 	add_executable(rosExample RosExample.cpp copyHalTest3Config)
 	target_link_libraries(rosExample eeros ${EEROS_LIBS})
+  list(APPEND targets rosExample)
 
 	add_executable(rosTest1 RosTest1.cpp)
 	target_link_libraries(rosTest1 eeros ${EEROS_LIBS})
+  list(APPEND targets rosTest1)
 	
 	add_executable(rosTest2 RosTest2.cpp copyHalTest2Config)
 	target_link_libraries(rosTest2 eeros ${EEROS_LIBS})
+  list(APPEND targets rosTest2)
+
+  if(INSTALL_EXAMPLES)
+    install(TARGETS ${targets} RUNTIME DESTINATION examples/ros)
+    install(FILES ${files} DESTINATION examples/ros)
+  endif()
 endif()

--- a/examples/rtTest/CMakeLists.txt
+++ b/examples/rtTest/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(rtTest rtTest.cpp)
 target_link_libraries(rtTest eeros ${EEROS_LIBS})
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS rtTest RUNTIME DESTINATION examples/rtTest)
+endif()
+

--- a/examples/sequencer/CMakeLists.txt
+++ b/examples/sequencer/CMakeLists.txt
@@ -1,64 +1,90 @@
+set(targets "")
 
 add_executable(sequencerTest10 SequencerTest10.cpp)
 target_link_libraries(sequencerTest10 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest10)
 
 add_executable(sequencerTest11 SequencerTest11.cpp)
 target_link_libraries(sequencerTest11 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest11)
 
 add_executable(sequencerTest12 SequencerTest12.cpp)
 target_link_libraries(sequencerTest12 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest12)
 
 add_executable(sequencerTest13 SequencerTest13.cpp)
 target_link_libraries(sequencerTest13 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest13)
 
 add_executable(sequencerTest14 SequencerTest14.cpp)
 target_link_libraries(sequencerTest14 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest14)
 
 add_executable(sequencerTest20 SequencerTest20.cpp)
 target_link_libraries(sequencerTest20 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest20)
 
 add_executable(sequencerTest21 SequencerTest21.cpp)
 target_link_libraries(sequencerTest21 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest21)
 
 add_executable(sequencerTest22 SequencerTest22.cpp)
 target_link_libraries(sequencerTest22 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest22)
 
 add_executable(sequencerTest23 SequencerTest23.cpp)
 target_link_libraries(sequencerTest23 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest23)
 
 add_executable(sequencerTest24 SequencerTest24.cpp)
 target_link_libraries(sequencerTest24 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest24)
 
 add_executable(sequencerTest25 SequencerTest25.cpp)
 target_link_libraries(sequencerTest25 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest25)
 
 add_executable(sequencerTest26 SequencerTest26.cpp)
 target_link_libraries(sequencerTest26 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest26)
 
 add_executable(sequencerTest30 SequencerTest30.cpp)
 target_link_libraries(sequencerTest30 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest30)
 
 add_executable(sequencerTest31 SequencerTest31.cpp)
 target_link_libraries(sequencerTest31 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest31)
 
 add_executable(sequencerTest32 SequencerTest32.cpp)
 target_link_libraries(sequencerTest32 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest32)
 
 add_executable(sequencerTest33 SequencerTest33.cpp)
 target_link_libraries(sequencerTest33 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest33)
 
 add_executable(sequencerTest34 SequencerTest34.cpp)
 target_link_libraries(sequencerTest34 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest34)
 
 add_executable(sequencerTest35 SequencerTest35.cpp)
 target_link_libraries(sequencerTest35 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest35)
 
 add_executable(sequencerTest36 SequencerTest36.cpp)
 target_link_libraries(sequencerTest36 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest36)
 
 add_executable(sequencerTest40 SequencerTest40.cpp)
 target_link_libraries(sequencerTest40 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest40)
 
 add_executable(sequencerTest41 SequencerTest41.cpp)
 target_link_libraries(sequencerTest41 eeros ${EEROS_LIBS})
+list(APPEND targets sequencerTest41)
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS ${targets} RUNTIME DESTINATION examples/sequencer)
+endif()
 

--- a/examples/socket/eerosClient/CMakeLists.txt
+++ b/examples/socket/eerosClient/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(socketClientExample SocketClientExample.cpp)
 target_link_libraries(socketClientExample eeros ${CMAKE_DL_LIBS} ucl)
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS socketClientExample RUNTIME DESTINATION examples/socket/eerosClient)
+endif()
+

--- a/examples/socket/eerosServer/CMakeLists.txt
+++ b/examples/socket/eerosServer/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(socketServerExample SocketServerExample.cpp)
 target_link_libraries(socketServerExample eeros ${CMAKE_DL_LIBS} ucl)
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS socketServerExample RUNTIME DESTINATION examples/socket/eerosServer)
+endif()
+

--- a/examples/socket/standaloneClient/CMakeLists.txt
+++ b/examples/socket/standaloneClient/CMakeLists.txt
@@ -1,1 +1,7 @@
 add_executable(standaloneSocketClientExample StandaloneClient.cpp)
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS standaloneSocketClientExample RUNTIME DESTINATION examples/socket/standaloneClient)
+endif()
+
+

--- a/examples/system/CMakeLists.txt
+++ b/examples/system/CMakeLists.txt
@@ -1,14 +1,31 @@
+set(files "")
+
 add_custom_command(OUTPUT copyConfig1 POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/system/SystemTest1Config.json" "${EEROS_BINARY_DIR}/examples/system")
+list(APPEND files ${EEROS_BINARY_DIR}/examples/system/SystemTest1Config.json)
+
 add_custom_command(OUTPUT copyConfig2 POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy "${EEROS_SOURCE_DIR}/examples/system/SystemTest2Config.json" "${EEROS_BINARY_DIR}/examples/system")
+list(APPEND files ${EEROS_BINARY_DIR}/examples/system/SystemTest2Config.json)
+
+set(targets "")
 
 add_executable(systemTest1 SystemTest1.cpp copyConfig1)
 target_link_libraries(systemTest1 eeros ${EEROS_LIBS})
+list(APPEND targets systemTest1)
 
 add_executable(systemTest2 SystemTest2.cpp copyConfig2)
 target_link_libraries(systemTest2 eeros ${EEROS_LIBS})
+list(APPEND targets systemTest2)
 
 add_executable(systemTest3 SystemTest3.cpp)
 target_link_libraries(systemTest3 eeros ${EEROS_LIBS})
+list(APPEND targets systemTest3)
 
 add_executable(mockRobotExample MockRobotExample.cpp)
 target_link_libraries(mockRobotExample eeros ${EEROS_LIBS})
+list(APPEND targets mockRobotExample)
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS ${targets} RUNTIME DESTINATION examples/system)
+  install(FILES ${files} DESTINATION examples/system)
+endif()
+

--- a/examples/task/CMakeLists.txt
+++ b/examples/task/CMakeLists.txt
@@ -1,8 +1,18 @@
+set(targets "")
+
 add_executable(periodicExample1 PeriodicExample1.cpp)
 target_link_libraries(periodicExample1 eeros ${EEROS_LIBS})
+list(APPEND targets periodicExample1)
 
 add_executable(periodicExample2 PeriodicExample2.cpp)
 target_link_libraries(periodicExample2 eeros ${EEROS_LIBS})
+list(APPEND targets periodicExample2)
 
 add_executable(periodicExample3 PeriodicExample3.cpp)
 target_link_libraries(periodicExample3 eeros ${EEROS_LIBS})
+list(APPEND targets periodicExample3)
+
+if(INSTALL_EXAMPLES)
+  install(TARGETS ${targets} RUNTIME DESTINATION examples/task)
+endif()
+


### PR DESCRIPTION
INSTALL_EXAMPLES cache variable is set to TRUE in CMakeLists.txt. So the examples are installed by default. If the user wishes to not install the examples,  the INSTALL_EXAMPLES variable can be set to FALSE via cmake-gui or cmake command.
```cmake
# cmake execution w/o examples installation
mkdir build; pushd build
cmake -DINSTALL_EXAMPLES=FALSE ..
```