### PR TITLE
Update Executor to work with new ecmasterlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,9 @@ INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/includes/eeros DESTINATION include
 
 ## Create and install CMake package configuration and package version files
 set(INCLUDE_INSTALL_DIR "include/")
-set(LIBUCL_INCLUDE_DIR "/usr/include")
+set(LIBUCL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libucl-src/include")
 set(LIB_INSTALL_DIR lib/)
-set(LIBUCL_LINK_DIR "/usr/lib")
+set(LIBUCL_LINK_DIR "${CMAKE_CURRENT_BINARY_DIR}/libucl-build")
 
 include(CMakePackageConfigHelpers)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,9 @@ INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/includes/eeros DESTINATION include
 
 ## Create and install CMake package configuration and package version files
 set(INCLUDE_INSTALL_DIR "include/")
-set(LIBUCL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libucl-src/include")
+set(LIBUCL_INCLUDE_DIR "/usr/include")
 set(LIB_INSTALL_DIR lib/)
-set(LIBUCL_LINK_DIR "${CMAKE_CURRENT_BINARY_DIR}/libucl-build/")
+set(LIBUCL_LINK_DIR "/usr/lib")
 
 include(CMakePackageConfigHelpers)
 

--- a/includes/eeros/core/Executor.hpp
+++ b/includes/eeros/core/Executor.hpp
@@ -9,6 +9,7 @@
 #include <eeros/task/Periodic.hpp>
 #include <eeros/logger/Logger.hpp>
 
+#define USE_ETHERCAT
 #ifdef USE_ETHERCAT
 #include <EcMasterlibMain.hpp>
 #endif

--- a/includes/eeros/core/Executor.hpp
+++ b/includes/eeros/core/Executor.hpp
@@ -10,7 +10,7 @@
 #include <eeros/logger/Logger.hpp>
 
 #ifdef USE_ETHERCAT
-#include <EtherCATStack.hpp>
+#include <EcMasterlibMain.hpp>
 #endif
 
 #ifdef USE_ROS
@@ -91,7 +91,7 @@ class Executor : public Runnable {
   static constexpr int basePriority = 49;
   PeriodicCounter counter;
 #ifdef USE_ETHERCAT
-  void syncWithEtherCATSTack(ecmasterlib::EtherCATStack* etherCATStack);
+  void syncWithEtherCATSTack(ecmasterlib::EcMasterlibMain* etherCATStack);
 #endif
 #ifdef USE_ROS
   void syncWithRosTime();
@@ -110,7 +110,7 @@ class Executor : public Runnable {
   bool syncWithRosTopicIsSet;
   logger::Logger log;
 #ifdef USE_ETHERCAT
-  ecmasterlib::EtherCATStack* etherCATStack;
+  ecmasterlib::EcMasterlibMain* etherCATStack;
 #endif
 };
 

--- a/includes/eeros/core/Executor.hpp
+++ b/includes/eeros/core/Executor.hpp
@@ -9,9 +9,8 @@
 #include <eeros/task/Periodic.hpp>
 #include <eeros/logger/Logger.hpp>
 
-#define USE_ETHERCAT
 #ifdef USE_ETHERCAT
-#include <EcMasterlibMain.hpp>
+#include <EtherCATStack.hpp>
 #endif
 
 #ifdef USE_ROS
@@ -92,7 +91,7 @@ class Executor : public Runnable {
   static constexpr int basePriority = 49;
   PeriodicCounter counter;
 #ifdef USE_ETHERCAT
-  void syncWithEtherCATSTack(ecmasterlib::EcMasterlibMain* etherCATStack);
+  void syncWithEtherCATSTack(ecmasterlib::EtherCATStack* etherCATStack);
 #endif
 #ifdef USE_ROS
   void syncWithRosTime();
@@ -111,7 +110,7 @@ class Executor : public Runnable {
   bool syncWithRosTopicIsSet;
   logger::Logger log;
 #ifdef USE_ETHERCAT
-  ecmasterlib::EcMasterlibMain* etherCATStack;
+  ecmasterlib::EtherCATStack* etherCATStack;
 #endif
 };
 

--- a/includes/eeros/core/Executor.hpp
+++ b/includes/eeros/core/Executor.hpp
@@ -111,8 +111,6 @@ class Executor : public Runnable {
   logger::Logger log;
 #ifdef USE_ETHERCAT
   ecmasterlib::EcMasterlibMain* etherCATStack;
-  std::mutex* m;
-  std::condition_variable* cv;
 #endif
 };
 

--- a/src/core/Executor.cpp
+++ b/src/core/Executor.cpp
@@ -108,7 +108,7 @@ Executor& Executor::instance() {
 
 
 #ifdef USE_ETHERCAT
-void Executor::syncWithEtherCATSTack(ecmasterlib::EtherCATStack* etherCATStack) {
+void Executor::syncWithEtherCATSTack(ecmasterlib::EcMasterlibMain* etherCATStack) {
   syncWithEtherCatStackIsSet = true;
   this->etherCATStack = etherCATStack;
 }

--- a/src/core/Executor.cpp
+++ b/src/core/Executor.cpp
@@ -22,6 +22,8 @@
 #include <ros/callback_queue.h>
 #endif
 
+#define USE_ETHERCAT
+
 volatile bool running = true;
 
 using namespace eeros;
@@ -262,7 +264,11 @@ void Executor::run() {
     useDefaultExecutor = false;
     
     while (running) {
-      etherCATStack->newDataAvailable.receive();
+      try {
+        etherCATStack->newDataAvailable.receive();
+      } catch (Channel<bool, 1>::ClosedException &ce) {
+        return; //stop if signaled by ethercat stack
+      }
       counter.tick();
       taskList.run();
       if (mainTask != nullptr)


### PR DESCRIPTION
These commits update the Executor to use the new `sync()` function provided by ecmasterlib for synchronization as well as updating the `stop()` method to use the new `EcMasterlibMian::stop()` to signal the EtherCAT stack to stop.
