### PR TITLE
update CMake configuration to target based configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(EEROS)
 
+include(GNUInstallDirs)
 
 ## Load CMake modules library at specified version
 set(LOAD_CMAKE_MODULES_LIB TRUE CACHE BOOL "TRUE if the cmake-modules library should be loaded.")
@@ -10,17 +11,14 @@ if(LOAD_CMAKE_MODULES_LIB)
   include(cmake/CMakeModulesLibLoader.cmake)
   load_cmake_modules_lib(https://github.com/eeros-project/cmake-modules.git)
 endif()
-
 include(CMakeModulesLib)
-if(CMAKE_BUILD_TYPE MATCHES "Debug|DEBUG")
-  logger_on()
-endif()
-
 if(LOAD_CMAKE_MODULES_LIB)
   checkout_cmake_modules_lib_version(a50add2)
 endif()
 
-
+if(CMAKE_BUILD_TYPE MATCHES "Debug|DEBUG")
+  logger_on()
+endif()
 
 ## Fetch the version information from git tag
 include(VersioningHelpers)
@@ -34,44 +32,7 @@ set(EEROS_VERSION ${EEROS_VERSION_MAJOR}.${EEROS_VERSION_MINOR}.${EEROS_VERSION_
 
 log("Going to build EEROS v${EEROS_VERSION}")
 
-
-## Add additional include and link directories
-include_directories(${ADDITIONAL_INCLUDE_DIRS})
-link_directories(${ADDITIONAL_LINK_DIRS})
-
-
-
-## Install all eeros header files
-INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/includes/eeros DESTINATION include)
-
-
-
-## Create and install CMake package configuration and package version files
-set(INCLUDE_INSTALL_DIR "include/")
-set(LIBUCL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libucl-src/include")
-set(LIB_INSTALL_DIR lib/)
-set(LIBUCL_LINK_DIR "${CMAKE_CURRENT_BINARY_DIR}/libucl-build")
-
 include(CMakePackageConfigHelpers)
-
-configure_package_config_file(
-  cmake/EEROSConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfig.cmake
-  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/EEROS/cmake
-  PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR LIBUCL_LINK_DIR)
-
-write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfigVersion.cmake
-  VERSION ${EEROS_VERSION}
-  COMPATIBILITY SameMajorVersion)
-
-install(
-  FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfigVersion.cmake
-  DESTINATION
-    ${LIB_INSTALL_DIR}/EEROS/cmake)
-
 
 
 ## Check environment
@@ -81,40 +42,6 @@ elseif(UNIX)
   set(POSIX TRUE) # Linux, BSD, Mac OS X, ...
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(LINUX TRUE) # GNU/Linux
-    
-    # Check for Xenomai
-    set(XENOMAI_SEARCH_PATH /usr/xenomai /usr) # set the search path
-    find_path(XENOMAI_DIR include/xeno_config.h ${XENOMAI_SEARCH_PATH}) # find xeno-config.h
-    if(XENOMAI_DIR) # Xenomai available
-      set(XENOMAI_INCLUDE_DIR ${XENOMAI_DIR}/include)
-      set(XENOMAI_INCLUDE_POSIX_DIR ${XENOMAI_DIR}/include/posix)
-      find_library(XENOMAI_LIBRARY_NATIVE  native  ${XENOMAI_DIR}/lib )
-      find_library(XENOMAI_LIBRARY_XENOMAI xenomai ${XENOMAI_DIR}/lib )
-      find_library(XENOMAI_LIBRARY_PTHREAD_RT pthread_rt rtdm ${XENOMAI_DIR}/lib )
-      find_library(XENOMAI_LIBRARY_RTDM    rtdm    ${XENOMAI_DIR}/lib )
-      find_file(XENOMAI_POSIX_WRAPPERS lib/posix.wrappers ${XENOMAI_SEARCH_PATH} ) # find the posix wrappers
-      set( XENOMAI_EXE_LINKER_FLAGS "-Wl,@${XENOMAI_POSIX_WRAPPERS}" ) # set the linker flags
-      set(XENOMAI_DEFINITIONS "-D_GNU_SOURCE -D_REENTRANT -Wall -pipe -D__XENO__") # add compile/preprocess options
-      include_directories(${XENOMAI_INCLUDE_DIR})
-      LINK_LIBRARIES(native ${XENOMAI_LIBRARY_NATIVE})
-      LINK_LIBRARIES(xenomai ${XENOMAI_LIBRARY_XENOMAI})
-      LINK_LIBRARIES(pthread_rt ${XENOMAI_LIBRARY_PTHREAD_RT})
-      LINK_LIBRARIES(rtdm ${XENOMAI_LIBRARY_RTDM})
-      set(XENOMAI TRUE)
-    endif(XENOMAI_DIR)
-    
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(FREEBSD TRUE) # FreeBSD
-  
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    set(MACOSX TRUE) # Mac OS X
-  
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    set(QNX TRUE) # QNX Neutrino
-
-    set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -ansi -D_POSIX_C_SOURCE=199506")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi -D_POSIX_C_SOURCE=199506")
-
   else()
     # Unkown UNIX
     message(WARNING "Unknown UNIX operating system!")
@@ -123,41 +50,6 @@ else()
   # Unkown OS
   message(WARNING "Unknown operating system!")
 endif()
-
-
-
-## Check and set C++ compiler flags
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX14)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-elseif(COMPILER_SUPPORTS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-  message(SEND_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler!")
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g") # Compile with debug symbols
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall") # Compile with all warnings
-
-
-
-## Use ncurses library if available
-find_file(LIBCURSES "curses.h" ${ADDITIONAL_INCLUDE_DIRS})
-if(LIBCURSES)
-  message(STATUS "-> libcurses available")
-  set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ncurses)
-endif()
-
-if(LINUX)
-  set(EXTERNAL_LIBS ${EXTERNAL_LIBS} -lrt)
-endif()
-
-
 
 ## download and builds libucl
 configure_file(CMakeLists.txt.in ${EEROS_BINARY_DIR}/libucl-download/CMakeLists.txt)
@@ -178,10 +70,68 @@ endif()
 add_subdirectory(${EEROS_BINARY_DIR}/libucl-src
                 ${EEROS_BINARY_DIR}/libucl-build)
 
-include_directories("${libucl_SOURCE_DIR}/include")
-link_directories(${libucl_BINARY_DIR})
+## Add subdirectories
+add_subdirectory(src) # EEROS framework
+
+add_library(eeros SHARED ${EEROS_SRCS})
+
+# include the eeros headers + eeros/config.cpp generateed earlier
+# There is probably a better way to do this (config.hpp) and ideally the headers should be part of the project sources anyway
+target_include_directories(eeros
+                            PUBLIC 
+                              $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/includes> 
+                              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+
+                              $<INSTALL_INTERFACE:include/eeros>)
+
+                              
+set_target_properties(eeros PROPERTIES
+                        VERSION ${EEROS_VERSION})
+
+target_compile_options(eeros PRIVATE -g -Wall PUBLIC -pthread)
+target_compile_features(eeros PUBLIC cxx_std_14)
+
+target_link_libraries(eeros PUBLIC pthread PRIVATE ucl ${CMAKE_DL_LIBS})
+
+if(LINUX)
+  target_link_libraries(eeros PRIVATE rt)
+endif()
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfigVersion.cmake
+  VERSION ${EEROS_VERSION}
+  COMPATIBILITY SameMinorVersion)
+
+## Configure and install config header file
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/includes/config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/eeros/config.hpp)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/eeros/config.hpp DESTINATION include/eeros)
+
+## Install all eeros header files
+INSTALL(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/includes/eeros DESTINATION include)
+
+install(TARGETS eeros
+        EXPORT EEROS
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)
+
+install(EXPORT EEROS DESTINATION ${CMAKE_INSTALL_LIBDIR}/EEROS/cmake)
+install(FILES EEROSConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/EEROS/cmake)
+
+install(
+  FILES
+    # ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/EEROSConfigVersion.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/EEROS/cmake)
 
 
+## Use ncurses library if available
+find_file(LIBCURSES "curses.h" ${ADDITIONAL_INCLUDE_DIRS})
+if(LIBCURSES)
+  message(STATUS "-> libcurses available")
+  target_link_libraries(eeros PRIVATE ncurses)
+
+endif()
 
 ## Use Find package ecmasterlib (EtherCAT) if found
 message(STATUS "--")
@@ -190,29 +140,15 @@ message(STATUS "EtherCAT")
 message(STATUS "**********************************")
 find_package(ecmasterlib QUIET)
 
-if (ECMASTERLIB_LIB_DIR AND USE_ETHERCAT)
+if (USE_ETHERCAT)
   message(STATUS "--> EtherCAT will be used")
-  include_directories("${ECMASTERLIB_INCLUDE_DIR}")
-  link_directories("${ECMASTERLIB_LIB_DIR}")
-  set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ecmasterlib)
-  set(LIBECMASTER "${ECMASTERLIB_INCLUDE_DIR}")
-  add_definitions(-DUSE_ETHERCAT)
-endif (ECMASTERLIB_LIB_DIR AND USE_ETHERCAT)
-
-if (NOT ECMASTERLIB_LIB_DIR AND USE_ETHERCAT)
-  message( FATAL_ERROR "ERROR: EtherCAT should be used but 'ecmasterlib' can not be found. Please install 'ecmasterlib'.")
-endif (NOT ECMASTERLIB_LIB_DIR AND USE_ETHERCAT)
-
-if (ECMASTERLIB_LIB_DIR AND NOT USE_ETHERCAT)
-  message(STATUS "--> 'ecmasterlib' is installed, but EtherCAT will NOT be used. You may want to use the -DUSE_ETHERCAT switch with cmake.")
-endif (ECMASTERLIB_LIB_DIR AND NOT USE_ETHERCAT)
-
-if (NOT ECMASTERLIB_LIB_DIR AND NOT USE_ETHERCAT)
-  message(STATUS "--> 'ecmasterlib' is NOT  installed. EtherCAT will NOT be used.")
-endif (NOT ECMASTERLIB_LIB_DIR AND NOT USE_ETHERCAT)
-message(STATUS "")
+  find_package(ecmasterlib REQUIRED)
+  target_link_libraries(eeros PUBLIC ecmasterlib)
+  target_compile_definitions(eeros PUBLIC USE_ETHERCAT EEROS_ETHERCAT)
+endif()
 
 
+# TODO: update for target based configuration
 
 ## Use CAN if instructed
 if(USE_CAN)
@@ -229,8 +165,6 @@ if(USE_CAN)
   endif()
   message(STATUS "")
 endif()
-
-
 
 ## Use MODBUS if instructed
 if(USE_MODBUS)
@@ -332,12 +266,6 @@ message(STATUS "")
 
 
 
-## Configure and install config header file
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/includes/config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/eeros/config.hpp)
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/eeros/config.hpp DESTINATION include/eeros)
-
-
-
 ## Set special variable for eclipse IDE
 set(CMAKE_ECLIPSE_GENERATE_SOURCE_PROJECT ON)
 
@@ -355,13 +283,11 @@ endif(DOXYGEN_FOUND)
 
 
 ## Set EEROS libraries
-set(EEROS_LIBS ${CMAKE_DL_LIBS} ucl pthread)
+#set(EEROS_LIBS ${CMAKE_DL_LIBS} ucl pthread)
+set(EEROS_LIBS ucl)
 
 ## Enable CTest
 enable_testing()
-
-## Add subdirectories
-add_subdirectory(src) # EEROS framework
 
 if(NOT LIB_ONLY_BUILD)
   add_subdirectory(tools)

--- a/EEROSConfig.cmake
+++ b/EEROSConfig.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(ecmasterlib)
+include(${CMAKE_CURRENT_LIST_DIR}/EEROS.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 macro(add_eeros_sources)
-    file(RELATIVE_PATH _relPath "${PROJECT_SOURCE_DIR}/src" "${CMAKE_CURRENT_SOURCE_DIR}")
+    file(RELATIVE_PATH _relPath "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
     foreach(_src ${ARGN})
         if(_relPath)
             list(APPEND EEROS_SRCS "${_relPath}/${_src}")
@@ -28,24 +28,5 @@ add_subdirectory(logger)
 add_subdirectory(config)
 # add_subdirectory(ui)
 
-link_directories(${EEROS_BINARY_DIR}/src/core)
-link_directories(${EEROS_BINARY_DIR}/src/math)
-link_directories(${EEROS_BINARY_DIR}/src/control)
-link_directories(${EEROS_BINARY_DIR}/src/hal)
-link_directories(${EEROS_BINARY_DIR}/src/sequencer)
-link_directories(${EEROS_BINARY_DIR}/src/socket)
-link_directories(${EEROS_BINARY_DIR}/src/safety)
-link_directories(${EEROS_BINARY_DIR}/src/logger)
-link_directories(${EEROS_BINARY_DIR}/src/config)
-# link_directories(${EEROS_BINARY_DIR}/src/ui)
-
-add_library(eeros SHARED ${EEROS_SRCS})
-
-target_link_libraries(eeros ${EXTERNAL_LIBS}) 
-
-
-set_target_properties(eeros PROPERTIES
-			VERSION ${EEROS_VERSION})
-
-
-INSTALL(TARGETS eeros LIBRARY DESTINATION lib)
+# EEROS_SRCS only exists in this CMakeLists.txt, so we need to explicitly set it in the main (parent) CmakeLists.txt
+set(EEROS_SRCS ${EEROS_SRCS} PARENT_SCOPE)


### PR DESCRIPTION
Die CMake Konfiguration ist vollstädig auf CMake targets umgestellt, wodurch alle Depenencies zwischen den Targets weitergereicht werden.

Für die weitere Vereinfachung mussten auch diverse Checks für Plattformen, von denen ich nicht wüsste, dass wir sie in den letzten Jahren je getestet haben, dran glauben. Wenn's die doch noc hbraucht, kann ich sie wieder einfügen.

Ich habe es mit ecmasterlib, den Teststand Beispielen und Simple Motor Control getestet und alle bauen.

Die Diffs sind etwas aufgeblasen, weil ich die Gelegenheit genutzt habe, das Haupt-CmakeLists.txt etwas zu sortieren.