### PR TITLE
fix compilation errors caused by Config const-weirdness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ set_target_properties(eeros PROPERTIES
                         VERSION ${EEROS_VERSION})
 
 target_compile_options(eeros PRIVATE -g -Wall PUBLIC -pthread)
-target_compile_features(eeros PUBLIC cxx_std_14)
+target_compile_features(eeros PUBLIC cxx_std_17)
 
 target_link_libraries(eeros PUBLIC pthread PRIVATE ucl ${CMAKE_DL_LIBS})
 

--- a/includes/eeros/config/Config.hpp
+++ b/includes/eeros/config/Config.hpp
@@ -2,20 +2,21 @@
 #define ORG_EEROS_CORE_CONFIG_HPP_
 
 #include <cmath>
-#include <map>
 #include <functional>
+#include <map>
 #include <string>
+#include <string_view>
 
 namespace eeros {
 namespace config {
 
 struct ConfigPropertyAccessor {
-  std::function<void(const std::string, std::string&)> set;
-  std::function<void(const std::string, const std::string)> get;
+  std::function<void(std::string, std::string &)> set;
+  std::function<void(std::string, std::string)> get;
 };
 
 struct StringCompare {
-  bool operator()(const std::string first, const std::string second) {
+  bool operator()(const std::string_view first, const std::string_view second) const {
     return first.compare(second) < 0;
   }
 };
@@ -56,24 +57,25 @@ class Config {
    * @return true if successful
    */
   virtual bool load(std::string path = "") = 0;
-    
- protected:
-  virtual void add(const std::string name, int &value);
-  virtual void add(const std::string name, double &value);
-  virtual void add(const std::string name, std::size_t length, int *start, int *end, int defaultValue = -1);
-  virtual void add(const std::string name, std::size_t length, double *start, double *end, double defaultValue = NAN);
-  virtual void add(const std::string name, std::string &value);
 
-  template < typename T, std::size_t N >
-  void add(const std::string name, std::array<T,N> &value);
-    
+protected:
+  virtual void add(std::string name, int &value);
+  virtual void add(std::string name, double &value);
+  virtual void add(std::string name, std::size_t length, int *start,
+                   int *end, int defaultValue = -1);
+  virtual void add(std::string name, std::size_t length,
+                   double *start, double *end, double defaultValue = NAN);
+  virtual void add(std::string name, std::string &value);
+
+  template <typename T, std::size_t N>
+  void add(std::string name, std::array<T, N> &value);
+
   std::string path;
   std::map<std::string, ConfigPropertyAccessor, StringCompare> properties;
 };
 
-
-template < typename T, std::size_t N >
-void Config::add(const std::string name, std::array<T,N> &value) {
+template <typename T, std::size_t N>
+void Config::add(std::string name, std::array<T, N> &value) {
   add(name, N, value.begin(), value.end());
 }
 

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -11,31 +11,31 @@ void Config::add(std::string name, int &value) {
     throw eeros::Fault(std::string("Property '") + name + "' already added.");
   }
   properties[name] = ConfigPropertyAccessor {
-    [&value] (const std::string name, std::string& val) -> void {
+    [&value] (std::string name, std::string& val) -> void {
       val = std::to_string(value);
     },
-    [&value] (const std::string name, const std::string val) -> void {
+    [&value] (std::string name, const std::string& val) -> void {
       value = std::stoi(val);
     }
   };
 }
 
-void Config::add(const std::string name, double &value) {
+void Config::add(std::string name, double &value) {
   auto k = properties.find(name);
   if (k != properties.end()) {
     throw eeros::Fault(std::string("Property '") + name + "' already added.");
   }
   properties[name] = ConfigPropertyAccessor {
-    [&value] (const std::string name, std::string& val) -> void {
+    [&value] (std::string name, std::string& val) -> void {
       val = std::to_string(value);
     },
-    [&value] (const std::string name, const std::string val) -> void {
+    [&value] (std::string name, const std::string& val) -> void {
       value = std::stod(val);
     }
   };
 }
 
-void Config::add(const std::string name, std::size_t length, int *start, int *end, int defaultValue) {
+void Config::add(std::string name, std::size_t length, int *start, int *end, int defaultValue) {
   if (start + length != end) {
     throw eeros::Fault(std::string("Property '") + name + "': array length inconsistent");
   }
@@ -44,7 +44,7 @@ void Config::add(const std::string name, std::size_t length, int *start, int *en
     throw eeros::Fault(std::string("Property '") + name + "' already added.");
   }
   properties[name] = ConfigPropertyAccessor{
-    [length, start] (const std::string name, std::string& val) -> void {
+    [length, start] (std::string name, std::string& val) -> void {
       std::stringstream ss;
       for (std::size_t i = 0; i < length; i++) {
         if (i != 0) ss << ", ";
@@ -52,7 +52,7 @@ void Config::add(const std::string name, std::size_t length, int *start, int *en
       }
       val = ss.str();
     },
-    [length, start, defaultValue] (const std::string name, const std::string val) -> void {
+    [length, start, defaultValue] (std::string name, const std::string& val) -> void {
       std::size_t i = 0;
       std::stringstream ss(val);
       std::string el;
@@ -67,7 +67,7 @@ void Config::add(const std::string name, std::size_t length, int *start, int *en
   };
 }
 
-void Config::add(const std::string name, std::size_t length, double *start, double *end, double defaultValue) {
+void Config::add(std::string name, std::size_t length, double *start, double *end, double defaultValue) {
   if (start + length != end) {
     throw eeros::Fault(std::string("Property '") + name + "': array length inconsistent");
   }
@@ -76,7 +76,7 @@ void Config::add(const std::string name, std::size_t length, double *start, doub
     throw eeros::Fault(std::string("Property '") + name + "' already added.");
   }
   properties[name] = ConfigPropertyAccessor {
-    [length, start] (const std::string name, std::string& val) -> void {
+    [length, start] (std::string name, std::string& val) -> void {
       std::stringstream ss;
       for (std::size_t i = 0; i < length; i++) {
         if (i != 0) ss << ", ";
@@ -84,9 +84,9 @@ void Config::add(const std::string name, std::size_t length, double *start, doub
       }
       val = ss.str();
     },
-    [length, start, defaultValue] (const std::string name, const std::string val) -> void {
+    [length, start, defaultValue] (std::string name, std::string val) -> void {
       std::size_t i = 0;
-      std::stringstream ss(val);
+      std::stringstream ss(std::move(val));
       std::string el;
       while (getline(ss, el, ',')) {
         double v = std::stod(el);
@@ -99,16 +99,16 @@ void Config::add(const std::string name, std::size_t length, double *start, doub
   };
 }
 
-void Config::add(const std::string name, std::string &value) {
+void Config::add(std::string name, std::string &value) {
   auto k = properties.find(name);
   if (k != properties.end()) {
     throw eeros::Fault(std::string("Property '") + name + "' already added.");
   }
   properties[name] = ConfigPropertyAccessor {
-    [&value] (const std::string name, std::string& val) -> void {
+    [&value] (std::string name, std::string& val) -> void {
       val = value;
     },
-    [&value] (const std::string name, const std::string val) -> void {
+    [&value] (std::string name, const std::string_view val) -> void {
       if (val.size() > 0) value = val.substr(1,val.size() - 1);
       else value = "";
     }


### PR DESCRIPTION
Newer compilers (at least GCC 9.3.0 11.2.0) fail to compile Config.hpp and Config.cpp due to const-correctness issues.
It looks like this was introduced when switching `Config` from `const char*` to `std::string` and not properly reconsidering their const-ness.

This PR applies a quick fix to remove the compilation errors, but we probably should take a really close look at Config.hpp/.cpp and do some refactoring. There are a lot of places where strings are copied instead of passing references or string_views and the assumptions about object lifetimes (particularly of function parameters e.g. in `Config::add`) seem questionable, at least from my cursory look at things.