### PR TITLE
Bugfix: Gain Multiplication Order

### DIFF
--- a/includes/eeros/control/Gain.hpp
+++ b/includes/eeros/control/Gain.hpp
@@ -292,7 +292,7 @@ class Gain : public Blockio<1,1,Tout> {
  private:
   template<typename S>
   typename std::enable_if<!elementWise, S>::type calculate(S value) {
-    return value * gain;
+    return gain * value;
   }
 
   template<typename S>


### PR DESCRIPTION
Fixed wrong multiplication order which lead to problems when multiplying a matrix with a vector.