### PR TITLE
Add specializations, mark others as deprecated

### DIFF
--- a/includes/eeros/control/Block1i.hpp
+++ b/includes/eeros/control/Block1i.hpp
@@ -13,10 +13,11 @@ namespace control {
  * 
  * @tparam T - input type (double - default type)
  * @since v0.4
+ * @deprecated Will be removed in future releases
  */
 
 template < typename T = double >
-class Block1i : public Block {
+class [[deprecated("Replaced by Blockio<1,0>")]] Block1i : public Block {
  public:
   /**
    * Constructs an block with one input.

--- a/includes/eeros/control/Block1i1o.hpp
+++ b/includes/eeros/control/Block1i1o.hpp
@@ -14,10 +14,11 @@ namespace control {
  * @tparam Tin - input type (double - default type)
  * @tparam Tout - output type (double - default type)
  * @since v0.4
+ * @deprecated Will be removed in future releases
  */
 
 template < typename Tin = double, typename Tout = Tin >
-class Block1i1o : public Block {
+class [[deprecated("Replaced by Blockio<1,1>")]] Block1i1o : public Block {
  public:
   /**
    * Constructs an block with one input and one output.

--- a/includes/eeros/control/Block1o.hpp
+++ b/includes/eeros/control/Block1o.hpp
@@ -13,10 +13,11 @@ namespace control {
  * 
  * @tparam T - output type (double - default type)
  * @since v0.4
+ * @deprecated Will be removed in future releases
  */
 
 template < typename T = double >
-class Block1o : public Block {
+class [[deprecated("Replaced by Blockio<0,1>")]]Block1o : public Block {
  public:
   /**
    * Constructs an block with one output.

--- a/includes/eeros/control/Blockio.hpp
+++ b/includes/eeros/control/Blockio.hpp
@@ -105,6 +105,125 @@ class Blockio : public Block {
 };
 
 /**
+ * Spezialization for several inputs and 1 output
+ */
+template < uint8_t N, typename Tin, typename Tout >
+class Blockio<N,1,Tin,Tout> : public Block {
+ public:
+  /**
+   * Construct an block with several inputs and one output. 
+   * Clears the output signal.
+   */
+  Blockio() : Blockio([](){}) { }
+
+  /**
+   * Construct an block with several inputs and one output.
+   * Clears the output signal.
+   * The block will run a given algorithm defined by the parameter function.
+   *
+   * @param f - function defining the algorithm
+   */
+  Blockio(std::function<void()> const &f) : out(this), func(f) {
+    for (uint8_t i = 0; i < N; i++) in[i].setOwner(this);
+    out.getSignal().clear();
+  }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Blockio(const Blockio& s) = delete; 
+
+  /**
+   * Runs the generic algorithm.
+   *
+   */
+  virtual void run() {
+    func();
+  }
+
+  /**
+   * Get an input of the block.
+   * 
+   * @param index - index of the input
+   * @return input
+   */
+  virtual Input<Tin>& getIn(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return in[index];
+  }
+
+  /**
+   * Get the output of the block.
+   * 
+   * @return output
+   */
+  virtual Output<Tout>& getOut() {
+    return out;
+  }
+
+ protected:
+  Input<Tin> in[N];
+  Output<Tout> out;
+
+ private:
+  std::function<void()> func;
+};
+
+/**
+ * Spezialization for several inputs and no output
+ */
+template < uint8_t N, typename Tin >
+class Blockio<N,0,Tin> : public Block {
+ public:
+  /**
+   * Construct an block with several inputs and one output. 
+   * Clears the output signal.
+   */
+  Blockio() : Blockio([](){}) { }
+
+  /**
+   * Construct an block with several inputs and one output.
+   * Clears the output signal.
+   * The block will run a given algorithm defined by the parameter function.
+   *
+   * @param f - function defining the algorithm
+   */
+  Blockio(std::function<void()> const &f) : func(f) {
+    for (uint8_t i = 0; i < N; i++) in[i].setOwner(this);
+  }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Blockio(const Blockio& s) = delete; 
+
+  /**
+   * Runs the generic algorithm.
+   *
+   */
+  virtual void run() {
+    func();
+  }
+
+  /**
+   * Get an input of the block.
+   * 
+   * @param index - index of the input
+   * @return input
+   */
+  virtual Input<Tin>& getIn(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return in[index];
+  }
+
+ protected:
+  Input<Tin> in[N];
+
+ private:
+  std::function<void()> func;
+};
+
+/**
  * Spezialization for 1 input and several outputs
  */
 template < uint8_t M, typename Tin, typename Tout >
@@ -172,71 +291,6 @@ class Blockio<1,M,Tin,Tout> : public Block {
 };
 
 /**
- * Spezialization for several inputs and 1 output
- */
-template < uint8_t N, typename Tin, typename Tout >
-class Blockio<N,1,Tin,Tout> : public Block {
- public:
-  /**
-   * Construct an block with several inputs and one output. 
-   * Clears the output signal.
-   */
-  Blockio() : Blockio([](){}) { }
-
-  /**
-   * Construct an block with several inputs and one output.
-   * Clears the output signal.
-   * The block will run a given algorithm defined by the parameter function.
-   *
-   * @param f - function defining the algorithm
-   */
-  Blockio(std::function<void()> const &f) : out(this), func(f) {
-    for (uint8_t i = 0; i < N; i++) in[i].setOwner(this);
-    out.getSignal().clear();
-  }
-
-  /**
-   * Disabling use of copy constructor because the block should never be copied unintentionally.
-   */
-  Blockio(const Blockio& s) = delete; 
-
-  /**
-   * Runs the generic algorithm.
-   *
-   */
-  virtual void run() {
-    func();
-  }
-
-  /**
-   * Get an input of the block.
-   * 
-   * @param index - index of the input
-   * @return input
-   */
-  virtual Input<Tin>& getIn(uint8_t index) {
-    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
-    return in[index];
-  }
-
-  /**
-   * Get the output of the block.
-   * 
-   * @return output
-   */
-  virtual Output<Tout>& getOut() {
-    return out;
-  }
-
- protected:
-  Input<Tin> in[N];
-  Output<Tout> out;
-
- private:
-  std::function<void()> func;
-};
-
-/**
  * Spezialization for 1 input and 1 output
  */
 template < typename Tin, typename Tout >
@@ -298,6 +352,202 @@ class Blockio<1,1,Tin,Tout> : public Block {
   std::function<void()> func;
 };
 
+/**
+ * Spezialization for 1 input and no output
+ */
+template < typename Tin >
+class Blockio<1,0,Tin> : public Block {
+ public:
+  /**
+   * Construct an block with one input and no output. 
+   */
+  Blockio() : Blockio([](){}) { }
+
+  /**
+   * Construct an block with one input and no output.
+   * Clears the output signal.
+   * The block will run a given algorithm defined by the parameter function.
+   *
+   * @param f - function defining the algorithm
+   */
+  Blockio(std::function<void()> const &f) : in(this), func(f) { }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Blockio(const Blockio& s) = delete; 
+
+  /**
+   * Runs the generic algorithm.
+   *
+   */
+  virtual void run() {
+    func();
+  }
+
+  /**
+   * Get the input of the block.
+   * 
+   * @return input
+   */
+  virtual Input<Tin>& getIn() {
+    return in;
+  }
+
+ protected:
+  Input<Tin> in;
+
+ private:
+  std::function<void()> func;
+};
+
+/**
+ * Spezialization for no input and several outputs
+ */
+template < uint8_t M, typename Tout >
+class Blockio<0,M,Tout> : public Block {
+ public:
+  /**
+   * Construct an block with no input and several outputs. 
+   * Clears the output signals.
+   */
+  Blockio() : Blockio([](){}) { }
+
+  /**
+   * Construct an block with no input and several outputs.
+   * Clears the output signals.
+   * The block will run a given algorithm defined by the parameter function.
+   *
+   * @param f - function defining the algorithm
+   */
+  Blockio(std::function<void()> const &f) : func(f) {
+    for (uint8_t i = 0; i < M; i++) {
+      out[i].setOwner(this);
+      out[i].getSignal().clear();
+    }
+  }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Blockio(const Blockio& s) = delete; 
+
+  /**
+   * Runs the generic algorithm.
+   *
+   */
+  virtual void run() {
+    func();
+  }
+
+  /**
+   * Get an output of the block.
+   * 
+   * @param index - index of the input
+   * @return output
+   */
+  virtual Output<Tout>& getOut(uint8_t index) {
+    if (index >= M) throw IndexOutOfBoundsFault("Trying to get inexistent element of output vector in block '" + this->getName() + "'"); 
+    return out[index];
+  }
+
+ protected:
+  Output<Tout> out[M];
+
+ private:
+  std::function<void()> func;
+};
+
+/**
+ * Spezialization for no input and one output
+ */
+template < typename Tout >
+class Blockio<0,1,Tout> : public Block {
+ public:
+  /**
+   * Construct an block with no input and one output. 
+   * Clears the output signals.
+   */
+  Blockio() : Blockio([](){}) { }
+
+  /**
+
+   * Construct an block with no input and one output.
+   * Clears the output signal.
+   * The block will run a given algorithm defined by the parameter function.
+   *
+   * @param f - function defining the algorithm
+   */
+  Blockio(std::function<void()> const &f) : func(f) {
+    out.setOwner(this);
+    out.getSignal().clear();
+  }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Blockio(const Blockio& s) = delete; 
+
+  /**
+   * Runs the generic algorithm.
+   *
+   */
+  virtual void run() {
+    func();
+  }
+
+  /**
+   * Get the output of the block.
+   * 
+   * @return output
+   */
+  virtual Output<Tout>& getOut() {
+    return out;
+  }
+
+ protected:
+  Output<Tout> out;
+
+ private:
+  std::function<void()> func;
+};
+
+/**
+ * Spezialization for no input and no output
+ */
+template < >
+class Blockio<0,0> : public Block {
+ public:
+  /**
+   * Construct an block with no input and no output. 
+   */
+  Blockio() : Blockio([](){}) { }
+
+  /**
+
+   * Construct an block with no input and no output.
+   * The block will run a given algorithm defined by the parameter function.
+   *
+   * @param f - function defining the algorithm
+   */
+  Blockio(std::function<void()> const &f) : func(f) { }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Blockio(const Blockio& s) = delete; 
+
+  /**
+   * Runs the generic algorithm.
+   *
+   */
+  virtual void run() {
+    func();
+  }
+
+ private:
+  std::function<void()> func;
+};
 
 /**
  * Operator overload (<<) to enable an easy way to print the state of a

--- a/includes/eeros/control/SignalChecker.hpp
+++ b/includes/eeros/control/SignalChecker.hpp
@@ -1,7 +1,7 @@
 #ifndef ORG_EEROS_CONTROL_SIGNALCHECKER_HPP_
 #define ORG_EEROS_CONTROL_SIGNALCHECKER_HPP_
 
-#include <eeros/control/Block1i.hpp>
+#include <eeros/control/Blockio.hpp>
 #include <eeros/safety/SafetyLevel.hpp>
 #include <eeros/safety/SafetySystem.hpp>
 #include <eeros/logger/Logger.hpp>
@@ -44,7 +44,7 @@ namespace control {
  */
 
 template<typename Tsig = double, typename Tlim = Tsig, bool checkNorm = false>
-class SignalChecker : public Block1i<Tsig> {
+class SignalChecker : public Blockio<1,0,Tsig> {
 
  public:
   /**

--- a/includes/eeros/control/SocketData.hpp
+++ b/includes/eeros/control/SocketData.hpp
@@ -1,7 +1,7 @@
 #ifndef ORG_EEROS_CONTROL_SOCKETDATA_HPP_
 #define ORG_EEROS_CONTROL_SOCKETDATA_HPP_
 
-#include <eeros/control/Block1i1o.hpp>
+#include <eeros/control/Blockio.hpp>
 #include <eeros/math/Matrix.hpp>
 #include <array>
 #include <eeros/core/System.hpp>
@@ -14,7 +14,7 @@ namespace control {
 using namespace sockets;
 
 template < typename SigInType, typename SigOutType, typename Enable = void >
-class SocketData: public Block1i1o<SigInType, SigOutType> { };
+class SocketData: public Blockio<1,1,SigInType, SigOutType> { };
 
 /**
  * This class allows to deliver a signal over a socket connection. While one end of the connection 
@@ -32,7 +32,7 @@ class SocketData: public Block1i1o<SigInType, SigOutType> { };
 template < typename SigInType, typename SigOutType>
 class SocketData<SigInType, SigOutType, 
   typename std::enable_if<std::is_compound<SigInType>::value && std::is_compound<SigOutType>::value>::type> 
-      : public Block1i1o<SigInType, SigOutType> {
+      : public Blockio<1,1,SigInType, SigOutType> {
  public:
    
   /**
@@ -142,7 +142,7 @@ class SocketData<SigInType, SigOutType,
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_arithmetic<SigInType>::value && std::is_compound<SigOutType>::value>::type> 
-  : public Block1i1o<SigInType, SigOutType> {			
+  : public Blockio<1,1,SigInType, SigOutType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufInLen = 1;
@@ -207,7 +207,7 @@ public:
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_compound<SigInType>::value && std::is_arithmetic<SigOutType>::value>::type> 
-  : public Block1i1o<SigInType, SigOutType> {			
+  : public Blockio<1,1,SigInType, SigOutType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufInLen = sizeof(SigInType) / sizeof(SigInValueType);
@@ -272,7 +272,7 @@ public:
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_arithmetic<SigInType>::value && std::is_arithmetic<SigOutType>::value>::type> 
-  : public Block1i1o<SigInType, SigOutType> {			
+  : public Blockio<1,1,SigInType, SigOutType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufInLen = 1;
@@ -336,7 +336,7 @@ public:
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_compound<SigInType>::value && std::is_same<SigOutType, std::nullptr_t>::value>::type> 
-  : public Block1i1o<SigInType> {			
+  : public Blockio<1,1,SigInType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufInLen = sizeof(SigInType) / sizeof(SigInValueType);
@@ -378,7 +378,7 @@ public:
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_same<SigInType, std::nullptr_t>::value && std::is_compound<SigOutType>::value>::type> 
-  : public Block1i1o<SigOutType> {			
+  : public Blockio<1,1,SigOutType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufOutLen = sizeof(SigOutType) / sizeof(SigOutValueType);
@@ -434,7 +434,7 @@ public:
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_arithmetic<SigInType>::value && std::is_same<SigOutType, std::nullptr_t>::value>::type> 
-  : public Block1i1o<SigInType> {			
+  : public Blockio<1,1,SigInType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufInLen = 1;
@@ -475,7 +475,7 @@ public:
 template < typename SigInType, typename SigOutType >
 class SocketData<SigInType, SigOutType,
   typename std::enable_if<std::is_same<SigInType, std::nullptr_t>::value && std::is_arithmetic<SigOutType>::value>::type> 
-  : public Block1i1o<SigOutType> {			
+  : public Blockio<1,1,SigOutType> {			
 public:
   SocketData(std::string serverIP, uint16_t port, double period = 0.01, double timeout = 1.0) {
     bufOutLen = 1;

--- a/test/control/Block.cpp
+++ b/test/control/Block.cpp
@@ -1,7 +1,4 @@
 #include <eeros/control/Block.hpp>
-#include <eeros/control/Block1i.hpp>
-#include <eeros/control/Block1o.hpp>
-#include <eeros/control/Block1i1o.hpp>
 #include <eeros/control/Blockio.hpp>
 #include <eeros/math/Matrix.hpp>
 
@@ -12,7 +9,7 @@ using namespace eeros;
 using namespace eeros::control;
 using namespace eeros::math;
 
-
+ 
 TEST(controlBlockTest, BlockFeatures) {
   class BlockStub : public Block {
    public:
@@ -27,38 +24,154 @@ TEST(controlBlockTest, BlockFeatures) {
 }
 
 
-TEST(controlBlockTest, Block1iFeatures) {
-  class Block1iStub : public Block1i<> {
+TEST(controlBlockTest, Block0i0oFeatures) {
+  class Block0i0oStub : public Blockio<0,0> {
    public:
     void run() {}
   };
 
-  Block1iStub block1i{};
-  EXPECT_EQ(typeid(block1i.getIn()), typeid(Input<double>));
+  Block0i0oStub block{};
 }
 
 
-TEST(controlBlockTest, Block1oFeatures) {
-  class Block1oStub : public Block1o<> {
+TEST(controlBlockTest, Block0i1oFeatures) {
+  class Block0i1oStub : public Blockio<0,1> {
    public:
     void run() {}
   };
 
-  Block1oStub block1o{};
-  EXPECT_EQ(typeid(block1o.getOut()), typeid(Output<double>));
+  Block0i1oStub block{};
+  EXPECT_EQ(typeid(block.getOut()), typeid(Output<double>));
+}
+
+
+TEST(controlBlockTest, Block0i2oFeatures) {
+  class Block0i2oStub : public Blockio<0,2> {
+   public:
+    void run() {}
+  };
+
+  Block0i2oStub block{};
+  block.setName("b1");
+  EXPECT_EQ(typeid(block.getOut(0)), typeid(Output<double>));
+  EXPECT_EQ(typeid(block.getOut(1)), typeid(Output<double>));
+  try {
+    EXPECT_EQ(typeid(block.getOut(2)), typeid(Output<double>));
+    FAIL();
+  } catch(eeros::Fault const & err) {
+    EXPECT_EQ(err.what(), std::string("Trying to get inexistent element of output vector in block 'b1'"));
+  }
+}
+
+
+TEST(controlBlockTest, Block1i0oFeatures) {
+  class Block1i0oStub : public Blockio<1,0> {
+   public:
+    void run() {}
+  };
+
+  Block1i0oStub block{};
+  EXPECT_EQ(typeid(block.getIn()), typeid(Input<double>));
 }
 
 
 TEST(controlBlockTest, Block1i1oFeatures) {
-  class Block1i1oStub : public Block1i1o<> {
+  class Block1i1oStub : public Blockio<1,1> {
    public:
     void run() {}
   };
 
-  Block1i1oStub block1i1o{};
-  EXPECT_EQ(typeid(block1i1o.getIn()), typeid(Input<double>));
-  EXPECT_EQ(typeid(block1i1o.getOut()), typeid(Output<double>));
+  Block1i1oStub block{};
+  EXPECT_EQ(typeid(block.getIn()), typeid(Input<double>));
+  EXPECT_EQ(typeid(block.getOut()), typeid(Output<double>));
 }
+
+
+TEST(controlBlockTest, Block1i2oFeatures) {
+  class Block1i2oStub : public Blockio<1,2> {
+   public:
+    void run() {}
+  };
+
+  Block1i2oStub block{};
+  block.setName("b2");
+  EXPECT_EQ(typeid(block.getIn()), typeid(Input<double>));
+  EXPECT_EQ(typeid(block.getOut(0)), typeid(Output<double>));
+  EXPECT_EQ(typeid(block.getOut(1)), typeid(Output<double>));
+  try {
+    EXPECT_EQ(typeid(block.getOut(2)), typeid(Output<double>));
+    FAIL();
+  } catch(eeros::Fault const & err) {
+    EXPECT_EQ(err.what(), std::string("Trying to get inexistent element of output vector in block 'b2'"));
+  }
+}
+
+
+TEST(controlBlockTest, Block2i0oFeatures) {
+  class Block2i0oStub : public Blockio<2,0> {
+   public:
+    void run() {}
+  };
+
+  Block2i0oStub block{};
+  block.setName("b3");
+  EXPECT_EQ(typeid(block.getIn(0)), typeid(Input<double>));
+  EXPECT_EQ(typeid(block.getIn(1)), typeid(Input<double>));
+  try {
+    EXPECT_EQ(typeid(block.getIn(2)), typeid(Input<double>));
+    FAIL();
+  } catch(eeros::Fault const & err) {
+    EXPECT_EQ(err.what(), std::string("Trying to get inexistent element of input vector in block 'b3'"));
+  }
+}
+
+
+TEST(controlBlockTest, Block2i1oFeatures) {
+  class Block2i1oStub : public Blockio<2,1> {
+   public:
+    void run() {}
+  };
+
+  Block2i1oStub block{};
+  block.setName("b4");
+  EXPECT_EQ(typeid(block.getIn(0)), typeid(Input<double>));
+  EXPECT_EQ(typeid(block.getIn(1)), typeid(Input<double>));
+  try {
+    EXPECT_EQ(typeid(block.getIn(2)), typeid(Input<double>));
+    FAIL();
+  } catch(eeros::Fault const & err) {
+    EXPECT_EQ(err.what(), std::string("Trying to get inexistent element of input vector in block 'b4'"));
+  }
+  EXPECT_EQ(typeid(block.getOut()), typeid(Output<double>));
+}
+
+
+TEST(controlBlockTest, Block2i2oFeatures) {
+  class Block2i2oStub : public Blockio<2,2> {
+   public:
+    void run() {}
+  };
+
+  Block2i2oStub block{};
+  block.setName("b5");
+  EXPECT_EQ(typeid(block.getIn(0)), typeid(Input<double>));
+  EXPECT_EQ(typeid(block.getIn(1)), typeid(Input<double>));
+  try {
+    EXPECT_EQ(typeid(block.getIn(2)), typeid(Input<double>));
+    FAIL();
+  } catch(eeros::Fault const & err) {
+    EXPECT_EQ(err.what(), std::string("Trying to get inexistent element of input vector in block 'b5'"));
+  }
+  EXPECT_EQ(typeid(block.getOut(0)), typeid(Output<double>));
+  EXPECT_EQ(typeid(block.getOut(1)), typeid(Output<double>));
+  try {
+    EXPECT_EQ(typeid(block.getOut(2)), typeid(Output<double>));
+    FAIL();
+  } catch(eeros::Fault const & err) {
+    EXPECT_EQ(err.what(), std::string("Trying to get inexistent element of output vector in block 'b5'"));
+  }
+}
+
 
 TEST(controlBlockTest, BlockioFeatures) {
   class BlockioStub1 : public Blockio<2,2> { };
@@ -107,13 +220,3 @@ TEST(controlBlockTest, BlockioFeatures) {
   BlockioStub8 s8{};
   EXPECT_EQ(typeid(s8.getOut()), typeid(Output<Vector2>));
 }
-
-TEST(controlBlockTest, BlockioFunction) {
-  class BlockioStub1 : public Blockio<2,2> { };
-  BlockioStub1 s1{};
-  EXPECT_EQ(typeid(s1.getIn(0)), typeid(Input<double>));
-  EXPECT_EQ(typeid(s1.getIn(1)), typeid(Input<double>));
-  EXPECT_EQ(typeid(s1.getOut(0)), typeid(Output<double>));
-  EXPECT_EQ(typeid(s1.getOut(1)), typeid(Output<double>));
-}
-


### PR DESCRIPTION
Blockio now has specializations for
- multiple inputs, 1 output
- multiple inputs, no output
- one input, multiple outputs
- one input, 1 output
- one input, no output
- no input, multiple outputs
- no input, 1 output
- no input, no output
Block1i, Block1o and Block1i10 were marked as deprecated