### PR TITLE
Added a lot of Ros2 classes, added signal enum and a bugfix

### DIFF
--- a/includes/eeros/control/Constant.hpp
+++ b/includes/eeros/control/Constant.hpp
@@ -88,6 +88,9 @@ private:
   template <typename S> typename std::enable_if<std::is_compound<S>::value && std::is_floating_point<typename S::value_type>::value>::type _clear() {
     value.fill(std::numeric_limits<double>::quiet_NaN());
   }
+  template<typename S> typename std::enable_if<std::is_enum<S>::value>::type _clear() {
+    value = static_cast<S>(0);
+  }
 };
 
 /********** Print functions **********/

--- a/includes/eeros/control/I.hpp
+++ b/includes/eeros/control/I.hpp
@@ -159,19 +159,19 @@ class I: public Blockio<1,1,T> {
   }
   template <typename S> typename std::enable_if<std::is_integral<S>::value>::type _clear() {
     upperLimit = std::numeric_limits<int32_t>::max();
-    lowerLimit = std::numeric_limits<int32_t>::min();
+    lowerLimit = std::numeric_limits<int32_t>::lowest();
   }
   template <typename S> typename std::enable_if<std::is_floating_point<S>::value>::type _clear() {
     upperLimit = std::numeric_limits<double>::max();
-    lowerLimit = std::numeric_limits<double>::min();
+    lowerLimit = std::numeric_limits<double>::lowest();
   }
   template <typename S> typename std::enable_if<!std::is_arithmetic<S>::value && std::is_integral<typename S::value_type>::value>::type _clear() {
     upperLimit.fill(std::numeric_limits<int32_t>::max());
-    lowerLimit.fill(std::numeric_limits<int32_t>::min());
+    lowerLimit.fill(std::numeric_limits<int32_t>::lowest());
   }
   template <typename S> typename std::enable_if<   !std::is_arithmetic<S>::value && std::is_floating_point<typename S::value_type>::value>::type _clear() {
     upperLimit.fill(std::numeric_limits<double>::max());
-    lowerLimit.fill(std::numeric_limits<double>::min());
+    lowerLimit.fill(std::numeric_limits<double>::lowest());
   }
 
 };

--- a/includes/eeros/control/I.hpp
+++ b/includes/eeros/control/I.hpp
@@ -159,19 +159,19 @@ class I: public Blockio<1,1,T> {
   }
   template <typename S> typename std::enable_if<std::is_integral<S>::value>::type _clear() {
     upperLimit = std::numeric_limits<int32_t>::max();
-    lowerLimit = -upperLimit;
+    lowerLimit = std::numeric_limits<int32_t>::min();
   }
   template <typename S> typename std::enable_if<std::is_floating_point<S>::value>::type _clear() {
     upperLimit = std::numeric_limits<double>::max();
-    lowerLimit = -upperLimit;
+    lowerLimit = std::numeric_limits<double>::min();
   }
   template <typename S> typename std::enable_if<!std::is_arithmetic<S>::value && std::is_integral<typename S::value_type>::value>::type _clear() {
     upperLimit.fill(std::numeric_limits<int32_t>::max());
-    lowerLimit = -upperLimit;
+    lowerLimit.fill(std::numeric_limits<int32_t>::min());
   }
   template <typename S> typename std::enable_if<   !std::is_arithmetic<S>::value && std::is_floating_point<typename S::value_type>::value>::type _clear() {
     upperLimit.fill(std::numeric_limits<double>::max());
-    lowerLimit = -upperLimit;
+    lowerLimit.fill(std::numeric_limits<double>::min());
   }
 
 };

--- a/includes/eeros/control/Input.hpp
+++ b/includes/eeros/control/Input.hpp
@@ -94,7 +94,7 @@ class Input {
   virtual void setOwner(Block* block) {
     owner = block;
   }
-      
+            
  protected:
   Output<T>* connectedOutput;
   Block* owner;

--- a/includes/eeros/control/Input.hpp
+++ b/includes/eeros/control/Input.hpp
@@ -94,20 +94,7 @@ class Input {
   virtual void setOwner(Block* block) {
     owner = block;
   }
-
-  /**
-   * Return the connected output
-   * If the input is not connected an NotConnectedFault
-   *
-   * @return Output
-   */
-  virtual Output<T>& getOutput() {
-    if(isConnected()) return *connectedOutput;
-    std::string name;
-    if (owner != nullptr) name = owner->getName(); else name = "";
-      throw NotConnectedFault("Tried to get an unconnnected block '" + name + "'");
-  }
-            
+      
  protected:
   Output<T>* connectedOutput;
   Block* owner;

--- a/includes/eeros/control/Input.hpp
+++ b/includes/eeros/control/Input.hpp
@@ -101,7 +101,7 @@ class Input {
    *
    * @return Output
    */
-  virtual Output<T>& getConOutput() {
+  virtual Output<T>& getOutput() {
     if(isConnected()) return *connectedOutput;
     std::string name;
     if (owner != nullptr) name = owner->getName(); else name = "";

--- a/includes/eeros/control/Input.hpp
+++ b/includes/eeros/control/Input.hpp
@@ -94,6 +94,19 @@ class Input {
   virtual void setOwner(Block* block) {
     owner = block;
   }
+
+  /**
+   * Return the connected output
+   * If the input is not connected an NotConnectedFault
+   *
+   * @return Output
+   */
+  virtual Output<T>& getConOutput() {
+    if(isConnected()) return *connectedOutput;
+    std::string name;
+    if (owner != nullptr) name = owner->getName(); else name = "";
+      throw NotConnectedFault("Tried to get an unconnnected block '" + name + "'");
+  }
             
  protected:
   Output<T>* connectedOutput;

--- a/includes/eeros/control/Signal.hpp
+++ b/includes/eeros/control/Signal.hpp
@@ -176,6 +176,9 @@ class Signal : public SignalInterface {
     value.fill(std::numeric_limits<double>::quiet_NaN());
     timestamp = 0;
   }
+  template<typename S> typename std::enable_if<std::is_enum<S>::value>::type _clear() {
+    value = static_cast<S>(0);
+  }
       
   static std::list<SignalInterface*> signalList;
   static Signal<T> illegalSignal;

--- a/includes/eeros/control/Signal.hpp
+++ b/includes/eeros/control/Signal.hpp
@@ -178,6 +178,7 @@ class Signal : public SignalInterface {
   }
   template<typename S> typename std::enable_if<std::is_enum<S>::value>::type _clear() {
     value = static_cast<S>(0);
+    timestamp = 0;
   }
       
   static std::list<SignalInterface*> signalList;

--- a/includes/eeros/control/ros2/EerosRosTools.hpp
+++ b/includes/eeros/control/ros2/EerosRosTools.hpp
@@ -1,7 +1,10 @@
+#ifdef USE_ROS2 /* header is only for use with ros2 */
+
 #ifndef EEROS_ROS_TOOLS_HPP
 #define EEROS_ROS_TOOLS_HPP
 
 #include <rclcpp/rclcpp.hpp>
+#include <eeros/logger/Logger.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 
 #define NS_PER_SEC 1000000000
@@ -12,12 +15,14 @@ namespace rosTools {
   
 /**
  * Helper functions for using ROS.
- * 
  * @since v1.0
+ * @deprecated
  */
   
 
 /**
+ * @deprecated Use EerosRos2Tools::toNanoSec(...)
+ * 
  * Converts a EEROS timestamp, which is in ns to ROS time in s.
  *
  * @param timestampNs - EEROS timestamp
@@ -33,6 +38,8 @@ static builtin_interfaces::msg::Time convertToRosTime(uint64_t timestampNs) {
 
 
 /**
+ * @deprecated Use EerosRos2Tools::toNanoSec(...)
+ * 
  * Creates an EEROS timestamp (nanoseconds) based on a ROS-Message-Header timestamp struct.
  *
  * @param time - the ROS-Message timestamp to convert
@@ -45,6 +52,8 @@ static uint64_t toNanoSec(const builtin_interfaces::msg::Time& time) {
 
 
 /**
+ * @deprecated Use EerosRos2Tools::initNode(...)
+ * 
  * Creates and initializes a ROS node.
  * Returns a shared pointer to the ROS Node.
  *
@@ -57,9 +66,98 @@ static rclcpp::Node::SharedPtr initNode(std::string name) {
   return rclcpp::Node::make_shared(name);
 }
 
+/**
+ * A fully static Class with Ros2 helpers
+ * 
+ * 
+*/
+class EerosRos2Tools {
+  public:
+  /* Delete this because this class is static only */
+  EerosRos2Tools() = delete;
+  EerosRos2Tools(const EerosRos2Tools&) = delete;
+  EerosRos2Tools(const EerosRos2Tools&&) = delete;
+  EerosRos2Tools& operator=(const EerosRos2Tools&) = delete;
 
-}
-}
-}
+  static void initRos2(int argc, char** argv){
+    if(!rclcpp::ok) {
+      rclcpp::InitOptions options;
+      const char* domain_id_env = std::getenv("ROS_DOMAIN_ID");
+      if (domain_id_env) {
+        try {
+          int domain_id = std::stoi(domain_id_env);
+          options.set_domain_id(domain_id);
+          logger::Logger::getLogger().trace() << "Set DOMAIN_ID to " << domain_id;
+        } catch (const std::exception& e) {
+          logger::Logger::getLogger().error() << "Error: invalid enviroment variable: ROS_DOMAIN_ID: " << domain_id_env;
+          logger::Logger::getLogger().trace() << " --> Using default: 0";
+          options.set_domain_id(0);
+        }
+      } else {
+        options.set_domain_id(0);
+        logger::Logger::getLogger().trace() << "ROS_DOMAIN_ID not set. Using default: 0";
+      }
+      std::atexit(cleanup); /* add function to call rclcpp::destroy at the end of the program */
+      rclcpp::init(argc,argv, options);
+    }
+  }
 
-#endif /* EEROS_ROS_TOOLS_HPP */
+  /**
+   * Creates and initializes a ROS node.
+   * Returns a shared pointer to the ROS Node.
+   *
+   * @param name - name of the ROS node
+   * @param letNodeSpin - if set to true it wil start a seperate thread to spin the node (needed for services, asynchrounus communication, ...)
+   * @return The ROS Node as a shared pointer
+   */
+  static rclcpp::Node::SharedPtr initNode(std::string nodeName, bool letNodeSpin = false) {
+    EerosRos2Tools::initRos2(0, NULL);
+    auto node = rclcpp::Node::make_shared(nodeName);
+    if(letNodeSpin) {
+      std::thread([node]() {
+        rclcpp::spin(node); /* Terminates when the node is destroyed or when rclcpp::shutdown is called. */
+      }).detach();
+    }
+    return node;
+  }
+
+  /**
+   * Converts a EEROS timestamp, which is in ns to ROS time in s.
+   *
+   * @param timestampNs - EEROS timestamp
+   * @return ROS time
+   */
+  static builtin_interfaces::msg::Time convertToRosTime(uint64_t timestampNs) {
+    builtin_interfaces::msg::Time t;
+    t.set__sec(static_cast<double>(timestampNs) / NS_PER_SEC);
+    t.set__nanosec(timestampNs % static_cast<uint64_t>(1e9));
+    return t;
+  }
+
+
+  /**
+   * Creates an EEROS timestamp (nanoseconds) based on a ROS-Message-Header timestamp struct.
+   *
+   * @param time - the ROS-Message timestamp to convert
+   * @return EEROS timestampNs
+   */
+  static uint64_t toNanoSec(const builtin_interfaces::msg::Time& time) {
+    return static_cast<uint64_t>(time.sec) * NS_PER_SEC + static_cast<uint64_t>(time.nanosec);
+  }
+
+  private:
+  static void cleanup(){
+    if(rclcpp::ok) {
+      rclcpp::shutdown();
+    }
+  }
+
+};
+
+} /* Namespace rosTools */
+} /* Namespace control */
+} /* Namespace eeros */
+
+#endif /* End EEROS_ROS_TOOLS_HPP*/
+
+#endif /* End USE_ROS2 */

--- a/includes/eeros/control/ros2/EerosRosTools.hpp
+++ b/includes/eeros/control/ros2/EerosRosTools.hpp
@@ -69,8 +69,7 @@ static rclcpp::Node::SharedPtr initNode(std::string name) {
 
 /**
  * A fully static Class with Ros2 helpers
- * It is recommended to use the initRos2 function first. (otherwise the call is implicit).
- * 
+ * You have to use rosInit first.
 */
 class EerosRos2Tools {
   public:
@@ -132,7 +131,7 @@ class EerosRos2Tools {
    * @return The ROS Node as a shared pointer
    */
   static rclcpp::Node::SharedPtr initNode(std::string nodeName, bool letNodeSpin = false) {
-    EerosRos2Tools::initRos2(0, nullptr);
+    assert(rclcpp::ok() && "rclcpp not initialized!");
     rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(nodeName);
     if(letNodeSpin) {
       std::thread([node]() {

--- a/includes/eeros/control/ros2/EerosRosTools.hpp
+++ b/includes/eeros/control/ros2/EerosRosTools.hpp
@@ -86,6 +86,12 @@ class EerosRos2Tools {
   EerosRos2Tools(const EerosRos2Tools&&) = delete;
   EerosRos2Tools& operator=(const EerosRos2Tools&) = delete;
 
+  /** 
+   * Initialized the rclcpp
+   * Read the enviroment variable "ROS_DOMAIN_ID" to set the domain id where ros2 has to be run.
+   * 
+   * It registers a function that will be called when the program ends to shut down rclcpp.
+   */
   static void initRos2(int argc, char** argv){
     if(!rclcpp::ok()) {
       rclcpp::InitOptions options;
@@ -112,8 +118,11 @@ class EerosRos2Tools {
   }
 
   /** 
-   * This function let register your own SIGINT handler along the
-   * ROS2 SIGINT handler
+   * This function let register your own SIGINT handler along the ROS2 SIGINT handler
+   * 
+   * It is recommended to call this immediately after the initRos2 function.
+   * 
+   * @throw std::runtime_error if rclcpp not initialized
    */
   static void registerCustomSigIntHandler(void (customHandler)(int)){
     CHECK_RCLCPP_OK();
@@ -143,6 +152,8 @@ class EerosRos2Tools {
    * @param name - name of the ROS node
    * @param letNodeSpin - if set to true it wil start a seperate thread to spin the node (needed for services, asynchrounus communication, ...)
    * @return The ROS Node as a shared pointer
+   * 
+   * @throw std::runtime_error if rclcpp not initialized
    */
   static rclcpp::Node::SharedPtr initNode(std::string nodeName, std::string nameSpace = "", bool letNodeSpin = false) {
     CHECK_RCLCPP_OK();
@@ -197,6 +208,7 @@ class EerosRos2Tools {
     }
   }
 
+  /* called if programm is shutting down */
   static void cleanup(){
     if(rclcpp::ok) {
       logger::Logger::getLogger().trace() << "rclcpp shutdown";

--- a/includes/eeros/control/ros2/EerosRosTools.hpp
+++ b/includes/eeros/control/ros2/EerosRosTools.hpp
@@ -130,9 +130,11 @@ class EerosRos2Tools {
    * @param letNodeSpin - if set to true it wil start a seperate thread to spin the node (needed for services, asynchrounus communication, ...)
    * @return The ROS Node as a shared pointer
    */
-  static rclcpp::Node::SharedPtr initNode(std::string nodeName, bool letNodeSpin = false) {
+  static rclcpp::Node::SharedPtr initNode(std::string nodeName, std::string nameSpace = "", bool letNodeSpin = false) {
     assert(rclcpp::ok() && "rclcpp not initialized!");
-    rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(nodeName);
+    rclcpp::NodeOptions opt;
+    
+    rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(nodeName, nameSpace);
     if(letNodeSpin) {
       std::thread([node]() {
         spin(node); /* Terminates when the node is destroyed or when rclcpp::shutdown is called. */

--- a/includes/eeros/control/ros2/EerosRosTools.hpp
+++ b/includes/eeros/control/ros2/EerosRosTools.hpp
@@ -133,7 +133,7 @@ class EerosRos2Tools {
    */
   static rclcpp::Node::SharedPtr initNode(std::string nodeName, bool letNodeSpin = false) {
     EerosRos2Tools::initRos2(0, nullptr);
-    rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("test");
+    rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(nodeName);
     if(letNodeSpin) {
       std::thread([node]() {
         spin(node); /* Terminates when the node is destroyed or when rclcpp::shutdown is called. */

--- a/includes/eeros/control/ros2/Ros2DoubleTo3DVector.hpp
+++ b/includes/eeros/control/ros2/Ros2DoubleTo3DVector.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <type_traits>
+#include <eeros/control/Blockio.hpp>
+#include <eeros/math/Matrix.hpp>
+#include <eeros/control/ros2/Ros2TypedefHelper.hpp>
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class is to convert a double (Alingend in a axe) to a 3D Vector.
+ * Input[i] and output[i] belongs together.
+ * 
+ * @tparam N Defines how many vectors has to be switched.
+ */
+template<uint8_t N = 1>
+class Ros2DoubleTo3DVector : public control::Blockio<0,0> {
+ public:
+ 
+  /**
+   * Special constructor if all doubles are in the same axe
+   * and the other value has to be filled with the same value by all.
+   * 
+   * @param provPlane: Specifies the axe to which the value is aligned.
+   * @param valueToFill: Defines the value with which the third dimension must be filled.
+   */
+  Ros2DoubleTo3DVector(Axe_t provAxe, 
+                       math::Vector2 valueToFill)
+    : Ros2DoubleTo3DVector(std::vector<Axe_t>(N, provAxe), std::vector<math::Vector2>(N, valueToFill)) {}
+  
+  /**
+   * Special constructor if all doubles are in different axes 
+   * and the other values has to be filled with the same value by all.
+   * 
+   * @param provPlane: Specifies the axe to which the value is aligned.
+   * @param valueToFill: Defines the value with which the other dimension must be filled.
+   */
+  Ros2DoubleTo3DVector(const std::vector<Axe_t> &provAxe, 
+                       math::Vector2 valueToFill)
+    : Ros2DoubleTo3DVector(provAxe, std::vector<math::Vector2>(N, valueToFill)) {}
+  
+  /**
+   * General constructor if all doubles are in different 2D planes 
+   * and the third value has to be different
+   * 
+   * @param provPlane: Specifies the axe to which the value is aligned.
+   * @param valueToFill: Defines the value with which the other dimension must be filled.
+   */
+  Ros2DoubleTo3DVector(const std::vector<Axe_t> &provAxe,
+                       const std::vector<math::Vector2> &valueToFill)
+    : provAxe_(provAxe),
+      valueToFill_(valueToFill) {
+    if(provAxe.size() != N || valueToFill.size() != N){
+      std::ostringstream oss;
+      oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t provided Axe and valueToFill must have the same size as N (Axe size: " << provAxe_.size() << ",valueToFill size: " << valueToFill.size() << ", N size: " << std::to_string(N) << ")";
+      throw eeros::Fault(oss.str());
+    }
+  }
+
+  /* switching fabric */
+  void run() override {
+    for(int i = 0; i<N; i++){
+      inTemp = this->in[i].getSignal().getValue();
+      switch(provAxe_[i]){
+        case AXE_X:
+            outTemp.set(0,0, inTemp);
+            outTemp.set(1,0, valueToFill_[i][0]);
+            outTemp.set(2,0, valueToFill_[i][1]);
+        break;
+        case AXE_Y:
+            outTemp.set(0,0, valueToFill_[i][0]);
+            outTemp.set(1,0, inTemp);
+            outTemp.set(2,0, valueToFill_[i][1]);
+        break;
+        case AXE_Z:
+            outTemp.set(0,0, valueToFill_[i][0]);
+            outTemp.set(1,0, valueToFill_[i][1]);
+            outTemp.set(2,0, inTemp);
+        break;
+        default:
+          std::ostringstream oss;
+          oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t In the switch of an enum, the default case is entred. Big Upsii";
+          throw eeros::Fault(oss.str());
+        break;
+      }
+      this->out[i].getSignal().setValue(outTemp);
+      this->out[i].getSignal().setTimestamp(this->in[i].getSignal().getTimestamp());
+    }
+  }
+
+  /**
+   * Get an input of the block.
+   * 
+   * @param index - index of the input
+   * @return input
+   */
+  virtual Input<double>& getIn(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return in[index];
+  }
+
+  /**
+   * Get the output of the block.
+   * 
+   * @return output
+   */
+  virtual Output<math::Vector3>& getOut(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of output vector in block '" + this->getName() + "'"); 
+    return out[index];
+  }
+
+ private:
+  const std::vector<Axe_t> provAxe_;
+  std::vector<math::Vector2> valueToFill_;
+  double inTemp;
+  math::Vector3 outTemp;
+
+  Input<double> in[N];
+  Output<math::Vector3> out[N];
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2DoubleTo3DVector.hpp
+++ b/includes/eeros/control/ros2/Ros2DoubleTo3DVector.hpp
@@ -48,6 +48,8 @@ class Ros2DoubleTo3DVector : public control::Blockio<0,0> {
    * 
    * @param provPlane: Specifies the axe to which the value is aligned.
    * @param valueToFill: Defines the value with which the other dimension must be filled.
+   * 
+   * @throw eeros::Fault is thrown if the vectors of both params and template n are not the same.
    */
   Ros2DoubleTo3DVector(const std::vector<Axe_t> &provAxe,
                        const std::vector<math::Vector2> &valueToFill)
@@ -95,7 +97,9 @@ class Ros2DoubleTo3DVector : public control::Blockio<0,0> {
    * Get an input of the block.
    * 
    * @param index - index of the input
-   * @return input
+   * @return input 
+   * 
+   * @throw eeros::control::IndexOutOfBoundsFault if index >= N
    */
   virtual Input<double>& getIn(uint8_t index) {
     if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
@@ -106,6 +110,8 @@ class Ros2DoubleTo3DVector : public control::Blockio<0,0> {
    * Get the output of the block.
    * 
    * @return output
+   * 
+   * @throw eeros::control::IndexOutOfBoundsFault if index >= N
    */
   virtual Output<math::Vector3>& getOut(uint8_t index) {
     if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of output vector in block '" + this->getName() + "'"); 

--- a/includes/eeros/control/ros2/Ros2PublisherOdometrie.hpp
+++ b/includes/eeros/control/ros2/Ros2PublisherOdometrie.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <eeros/control/ros2/RosPublisher.hpp>
+#include <eeros/control/ros2/EerosRosTools.hpp>
+#include <eeros/control/Block.hpp>
+#include <eeros/math/Matrix.hpp>
+#include <eeros/control/Output.hpp>
+#include <eeros/control/Input.hpp>
+
+#include <nav_msgs/msg/odometry.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+#include <eeros/core/System.hpp>
+#include <array>
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+
+/**
+ * This block will creates a odom message from the input signals and publishes it.
+ * Pose -> Describes the position of the robot since the start.
+ */
+class Ros2PublisherOdometrie : public RosPublisher<nav_msgs::msg::Odometry, uint8_t>{
+ public:
+
+  /**
+   * 
+   * @param node - ROS node as a shared ptr
+   * @param topic - name of the topic
+   * @param queueSize - maximum number of outgoing messages to be queued for delivery to subscribers
+   */ 
+  Ros2PublisherOdometrie(const rclcpp::Node::SharedPtr node, 
+                         const std::string& topic,
+                         std::string robotBaseFrame,
+                         std::string odomFrame,
+                         const uint32_t queueSize=1000)
+    : RosPublisher<nav_msgs::msg::Odometry, uint8_t>(node, topic, queueSize),
+      robotBaseFrame(robotBaseFrame),
+      odomFrame(odomFrame),
+      clock(node->get_clock()) { 
+    CHECK_RCLCPP_OK();
+  }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Ros2PublisherOdometrie(const Ros2PublisherOdometrie& other) = delete;
+
+  virtual void setRosMsg(nav_msgs::msg::Odometry& msg) override {
+    msg.header.frame_id = odomFrame;
+    msg.header.stamp = clock->now();
+    msg.child_frame_id = robotBaseFrame;
+    msg.twist.twist.linear.x = inTwistTranslation.getSignal().getValue()[0];
+    msg.twist.twist.linear.y = inTwistTranslation.getSignal().getValue()[1];
+    msg.twist.twist.linear.z = inTwistTranslation.getSignal().getValue()[2];
+    msg.twist.twist.angular.z = inTwistRotation.getSignal().getValue()[0];
+    msg.twist.twist.angular.x = inTwistRotation.getSignal().getValue()[1];
+    msg.twist.twist.angular.y = inTwistRotation.getSignal().getValue()[2];
+    msg.pose.pose.position.x = inPoseTranslation.getSignal().getValue()[0];
+    msg.pose.pose.position.y = inPoseTranslation.getSignal().getValue()[1];
+    msg.pose.pose.position.z = inPoseTranslation.getSignal().getValue()[2];
+    temp = inPoseRotation.getSignal().getValue();
+    quat.setRPY(temp[0], temp[1], temp[2]);
+    msg.pose.pose.orientation.x = quat.getX();
+    msg.pose.pose.orientation.y = quat.getY();
+    msg.pose.pose.orientation.z = quat.getZ();
+    msg.pose.pose.orientation.w = quat.getW();
+    msg.twist.covariance = inCovarianzTwist.getSignal().getValue();
+    msg.pose.covariance = inCovarianzPose.getSignal().getValue();
+  }
+
+  inline control::Input<math::Vector3>& getInPoseTranslation(){return inPoseTranslation;}
+  inline control::Input<math::Vector3>& getInPoseRotation(){return inPoseRotation;}
+  inline control::Input<math::Vector3>& getInTwistTranslation(){return inTwistTranslation;}
+  inline control::Input<math::Vector3>& getInTwistRotation(){return inTwistRotation;}
+  inline control::Input<std::array<double,36>>& getInCovarPose(){return inCovarianzPose;}
+  inline control::Input<std::array<double,36>>& getInCovarTwist(){return inCovarianzTwist;}
+
+ private:
+  control::Input<math::Vector3> inPoseTranslation;
+  control::Input<math::Vector3> inPoseRotation;
+  control::Input<math::Vector3> inTwistTranslation;
+  control::Input<math::Vector3> inTwistRotation;
+  control::Input<std::array<double,36>> inCovarianzPose;
+  control::Input<std::array<double,36>> inCovarianzTwist;
+  math::Vector3 temp;
+  tf2::Quaternion quat;
+
+  std::string robotBaseFrame;
+  std::string odomFrame;
+  rclcpp::Clock::SharedPtr clock;
+};
+
+} /* END: Namespace control */
+} /* END: Namespace eeros */

--- a/includes/eeros/control/ros2/Ros2StaticTransformBroadcaster.hpp
+++ b/includes/eeros/control/ros2/Ros2StaticTransformBroadcaster.hpp
@@ -23,57 +23,67 @@ namespace control {
  */
 class Ros2StaticTransformBroadcaster {
 public:
-    static Ros2StaticTransformBroadcaster& getInstance(rclcpp::Node::SharedPtr node, uint32_t queueSize = 1000) {
-        static Ros2StaticTransformBroadcaster instance(node, queueSize);
-        return instance;
-    }
 
-    /**
-     * Broadcast a single static Tf
-     * If you need to send multiple TFs, use the overload feature (better performance).
-     * 
-     * @param tf: The static tf to broadcast
-     */
-    void addTf(const geometry_msgs::msg::TransformStamped& tf) {
-        static_tf_broadcaster->sendTransform(tf);
-        tfs.push_back(tf);
-    }
+  /** 
+   * Singleton
+   * The first call requires the params. Second or later calls do not require params.
+   * 
+   * @param node - The node from which the tf's must be sent.
+   * @param queueSize - rclcpp quality of service
+   * 
+   * @throw std::runtime_error if node is nullptr
+   */
+  static Ros2StaticTransformBroadcaster& getInstance(rclcpp::Node::SharedPtr node = nullptr, uint32_t queueSize = 1000) {
+    static Ros2StaticTransformBroadcaster instance(node, queueSize);
+    return instance;
+  }
 
-    /**
-     * Broadcast a list of static Tf
-     * 
-     * @param tf: The static tf list to broadcast
-     */
-    void addTf(const std::vector<geometry_msgs::msg::TransformStamped>& tf) {
-        static_tf_broadcaster->sendTransform(tf);
-        tfs.insert(tfs.end(), tf.begin(), tf.end());
-    }
+  /**
+   * Broadcast a single static Tf
+   * If you need to send multiple TFs, use the overload feature (better performance).
+   * 
+   * @param tf: The static tf to broadcast
+   */
+  void addTf(const geometry_msgs::msg::TransformStamped& tf) {
+    static_tf_broadcaster->sendTransform(tf);
+    tfs.push_back(tf);
+  }
 
-    /**
-     * Returns a list of all published tf's
-     */
-    std::vector<geometry_msgs::msg::TransformStamped> getTfs() const {
-        return tfs;
-    }
+  /**
+   * Broadcast a list of static Tf
+   * 
+   * @param tf: The static tf list to broadcast
+   */
+  void addTf(const std::vector<geometry_msgs::msg::TransformStamped>& tf) {
+    static_tf_broadcaster->sendTransform(tf);
+    tfs.insert(tfs.end(), tf.begin(), tf.end());
+  }
+
+  /**
+   * Returns a list of all published tf's
+   */
+  std::vector<geometry_msgs::msg::TransformStamped> getTfs() const {
+    return tfs;
+  }
 
 private:
-    Ros2StaticTransformBroadcaster(rclcpp::Node::SharedPtr node, uint32_t queueSize)
-        : node(node),
-          log(eeros::logger::Logger::getLogger('t')) {
-        if (!node) {
-            throw std::runtime_error("Node must not be null");
-        }
-        static_tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node, queueSize);
-        log.info() << "ROS TF static broadcaster generated on node '" << node->get_name() << "'";
+  Ros2StaticTransformBroadcaster(rclcpp::Node::SharedPtr node, uint32_t queueSize)
+    : node(node),
+      log(eeros::logger::Logger::getLogger('t')) {
+    if (!node) {
+      throw std::runtime_error("Node must not be null");
     }
+    static_tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node, queueSize);
+    log.info() << "ROS TF static broadcaster generated on node '" << node->get_name() << "'";
+  }
 
-    Ros2StaticTransformBroadcaster(const Ros2StaticTransformBroadcaster&) = delete;
-    Ros2StaticTransformBroadcaster& operator=(const Ros2StaticTransformBroadcaster&) = delete;
+  Ros2StaticTransformBroadcaster(const Ros2StaticTransformBroadcaster&) = delete;
+  Ros2StaticTransformBroadcaster& operator=(const Ros2StaticTransformBroadcaster&) = delete;
 
-    rclcpp::Node::SharedPtr node;
-    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster;
-    eeros::logger::Logger log;
-    std::vector<geometry_msgs::msg::TransformStamped> tfs;
+  rclcpp::Node::SharedPtr node;
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster;
+  eeros::logger::Logger log;
+  std::vector<geometry_msgs::msg::TransformStamped> tfs;
 };
 
 } /* END Namespace: control */

--- a/includes/eeros/control/ros2/Ros2StaticTransformBroadcaster.hpp
+++ b/includes/eeros/control/ros2/Ros2StaticTransformBroadcaster.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <vector>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <eeros/logger/Logger.hpp>
+#include <eeros/control/ros2/EerosRosTools.hpp>
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class is used to publish a tf frame to the global tf tree.
+ * 
+ * This is only for static transformations.
+ * It will not publish the transformation continuously.
+ * For dynamic transformations, see the class: eeros::control::Ros2TransformBroadcaster.hpp
+ */
+class Ros2StaticTransformBroadcaster {
+public:
+    static Ros2StaticTransformBroadcaster& getInstance(rclcpp::Node::SharedPtr node, uint32_t queueSize = 1000) {
+        static Ros2StaticTransformBroadcaster instance(node, queueSize);
+        return instance;
+    }
+
+    /**
+     * Broadcast a single static Tf
+     * If you need to send multiple TFs, use the overload feature (better performance).
+     * 
+     * @param tf: The static tf to broadcast
+     */
+    void addTf(const geometry_msgs::msg::TransformStamped& tf) {
+        static_tf_broadcaster->sendTransform(tf);
+        tfs.push_back(tf);
+    }
+
+    /**
+     * Broadcast a list of static Tf
+     * 
+     * @param tf: The static tf list to broadcast
+     */
+    void addTf(const std::vector<geometry_msgs::msg::TransformStamped>& tf) {
+        static_tf_broadcaster->sendTransform(tf);
+        tfs.insert(tfs.end(), tf.begin(), tf.end());
+    }
+
+    /**
+     * Returns a list of all published tf's
+     */
+    std::vector<geometry_msgs::msg::TransformStamped> getTfs() const {
+        return tfs;
+    }
+
+private:
+    Ros2StaticTransformBroadcaster(rclcpp::Node::SharedPtr node, uint32_t queueSize)
+        : node(node),
+          log(eeros::logger::Logger::getLogger('t')) {
+        if (!node) {
+            throw std::runtime_error("Node must not be null");
+        }
+        static_tf_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node, queueSize);
+        log.info() << "ROS TF static broadcaster generated on node '" << node->get_name() << "'";
+    }
+
+    Ros2StaticTransformBroadcaster(const Ros2StaticTransformBroadcaster&) = delete;
+    Ros2StaticTransformBroadcaster& operator=(const Ros2StaticTransformBroadcaster&) = delete;
+
+    rclcpp::Node::SharedPtr node;
+    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster;
+    eeros::logger::Logger log;
+    std::vector<geometry_msgs::msg::TransformStamped> tfs;
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2SubscriberTwist.hpp
+++ b/includes/eeros/control/ros2/Ros2SubscriberTwist.hpp
@@ -25,6 +25,8 @@ class Ros2SubscriberTwist : public RosSubscriber<ros2_msg_t, math::Vector3>{
    * @param node - ROS node as a shared ptr
    * @param topic - name of the topic
    * @param queueSize - maximum number of outgoing messages to be queued for delivery to subscribers
+   * 
+   * @throw std::runtime_error if rclcpp is not initialized
    */ 
   Ros2SubscriberTwist(const rclcpp::Node::SharedPtr node, 
                        const std::string& topic, 

--- a/includes/eeros/control/ros2/Ros2SubscriberTwist.hpp
+++ b/includes/eeros/control/ros2/Ros2SubscriberTwist.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <eeros/control/ros2/RosSubscriber.hpp>
+#include <eeros/control/ros2/EerosRosTools.hpp>
+#include <eeros/math/Matrix.hpp>
+#include <eeros/core/System.hpp>
+
+#include <geometry_msgs/msg/twist.hpp>
+
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This block subscribes a Twist msg
+ */
+typedef geometry_msgs::msg::Twist ros2_msg_t;
+class Ros2SubscriberTwist : public RosSubscriber<ros2_msg_t, math::Vector3>{
+ public:
+
+  /**
+   * 
+   * @param node - ROS node as a shared ptr
+   * @param topic - name of the topic
+   * @param queueSize - maximum number of outgoing messages to be queued for delivery to subscribers
+   */ 
+  Ros2SubscriberTwist(const rclcpp::Node::SharedPtr node, 
+                       const std::string& topic, 
+                       const uint32_t queueSize=1000)
+    : RosSubscriber<ros2_msg_t, math::Vector3>(node, topic, false, queueSize){
+    CHECK_RCLCPP_OK();
+  }
+
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  Ros2SubscriberTwist(const Ros2SubscriberTwist&) = delete;
+
+  virtual void parseMsg(const ros2_msg_t& msg) override {
+    out.getSignal().setValue({msg.linear.x, msg.linear.y, msg.linear.z});
+    out.getSignal().setTimestamp(eeros::System::getTimeNs());
+    outAngular.getSignal().setValue({msg.angular.x, msg.angular.y, msg.angular.z});
+    outAngular.getSignal().setTimestamp(eeros::System::getTimeNs());
+  }
+
+   /**
+   * Get rotation of a twist message
+   * 
+   * @return input
+   */
+  virtual Output<math::Vector3>& getOutAngular() {return outAngular;}
+
+ private:
+  Output<math::Vector3> outAngular;
+};
+
+} /* END: Namespace control */
+} /* END: Namespace eeros */

--- a/includes/eeros/control/ros2/Ros2TransformBroadcaster.hpp
+++ b/includes/eeros/control/ros2/Ros2TransformBroadcaster.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <mutex>
+
+#include <eeros/control/Block.hpp>
+#include <eeros/logger/Logger.hpp>
+#include <eeros/control/ros2/EerosRosTools.hpp>
+#include <eeros/control/Input.hpp>
+#include <eeros/math/Matrix.hpp>
+#include <eeros/control/Output.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class is used to publish a tf frame to the global tf tree.
+ * 
+ * @tparam N defines how many publication to the tf tree
+ * @tparam N Must fullfill: N == frames.size
+ * 
+ * This is only for dynamic transformations.
+ * For static transformation see class: eeros::control::Ros2StaticTransformBroadcaster.hpp
+ */
+template<uint8_t N>
+class Ros2TransformBroadcaster : public Block {
+ public:
+
+  /**
+   * Creates a tf listener for dynamic tf's
+   * 
+   * @param node: a rclcpp node (dosent depend whitch one. Only for Ros clock needed)
+   * @param frames: first element parent second element child frame
+   *                Index n belongs to output n
+   * @param queueSize: rclcpp QoS 
+   */
+  Ros2TransformBroadcaster(rclcpp::Node::SharedPtr node,
+                           const std::vector<std::pair<std::string, std::string>>& frames_, 
+                           uint32_t queueSize=1000)
+    : running(false),
+      node(node),
+      frames(frames_),
+      log(logger::Logger::getLogger('t')) {
+    static uint8_t objectCount = 0;
+    static std::mutex mtx;
+    if(frames.size() != N){
+        std::ostringstream oss;
+        oss << __FILE__ << "::" << __LINE__ << "\n frames (size: " << frames.size() << ") must have the same length as template param N=" << N;
+        throw eeros::Fault(oss.str());
+    }
+    for(int i = 0; i<N; i++){
+      lastErrTime[i] = 0;
+      if(frames[i].first.compare(frames[i].second) == 0) {
+        log.warn() << "Parent and child frame are the same. Parent: '" << frames[i].first <<"' Child: '" << frames[i].second << "'";
+      }
+    }
+    
+    /* Checker to warn if more than one instance is created */
+    mtx.lock();
+    if(objectCount != 0){
+      log.warn() << "Created multiple instance of class Ros2TransformBroadcaster.";
+      log.warn() << " -> It is recommended to create only one instance!!!";
+    }
+    objectCount++;
+    mtx.unlock();
+    
+    CHECK_RCLCPP_OK();
+    tf_broadcaster = std::make_shared<tf2_ros::TransformBroadcaster>(node, queueSize);
+    log.info() << "Ros tf broadcaster generated ' on node '" << node->get_name();
+   
+    running = true;
+  }
+
+  virtual void run() {
+    if(running) {
+      for(uint8_t i = 0; i<N;i++){
+        inTrans = inPoseTranslation[i].getSignal().getValue();
+        inRot = inPoseRotation[i].getSignal().getValue();
+        /* if one number is nan skip */
+        if(this->hasNaN(inTrans) || this->hasNaN(inRot)){
+          if(lastErrTime[i] + 2000000000 < System::getTimeNs()){
+            log.warn() << "Couldent pubish tf: '" << frames[i].first << "' to '" << frames[i].second << "' due to NaN in values";
+            lastErrTime[i] = System::getTimeNs();
+          }
+          continue;
+        }
+        msg.child_frame_id = frames[i].second;
+        msg.header.frame_id = frames[i].first;
+        msg.header.stamp = node->get_clock()->now();
+        msg.transform.translation.x = inTrans[0];
+        msg.transform.translation.y = inTrans[1];
+        msg.transform.translation.z = inTrans[2];
+        quaternion.setRPY(inRot[0], inRot[1], inRot[2]);
+        msg.transform.rotation.x = quaternion.x();
+        msg.transform.rotation.y = quaternion.y();
+        msg.transform.rotation.z = quaternion.z();
+        msg.transform.rotation.w = quaternion.w();
+        tf_broadcaster->sendTransform(msg);
+      }
+    }
+  }
+  
+  /**
+   * Get the input for translation
+   * 
+   * @param index Index has the same function as getInPoseRotation. It belongs to a tf
+   * @return the Input
+   */
+  inline control::Input<math::Vector3>& getInPoseTranslation(const uint8_t index){
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return inPoseTranslation[index];
+  }
+
+  /**
+   * Get the input for rotation
+   * 
+   * @param index Index has the same function as getInPoseTranslation. It belongs to a tf
+   * @return the Input
+   */
+  inline control::Input<math::Vector3>& getInPoseRotation(const uint8_t index){
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return inPoseRotation[index];
+  }
+
+ protected:
+  rclcpp::Node::SharedPtr node;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster;
+  bool running;
+  eeros::logger::Logger log;
+  geometry_msgs::msg::TransformStamped msg;
+  const std::vector<std::pair<std::string, std::string>> frames;
+  control::Input<math::Vector3> inPoseTranslation[N];
+  control::Input<math::Vector3> inPoseRotation[N];
+  math::Vector3 inTrans;
+  math::Vector3 inRot;
+  uint64_t lastTime = 0;
+  tf2::Quaternion quaternion;
+  uint64_t lastErrTime[N];
+
+ private:
+  bool hasNaN(math::Vector3 x){
+    return std::isnan(x[0]+x[1]+x[2]);
+  }
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2TransformBroadcaster.hpp
+++ b/includes/eeros/control/ros2/Ros2TransformBroadcaster.hpp
@@ -39,6 +39,9 @@ class Ros2TransformBroadcaster : public Block {
    * @param frames: first element parent second element child frame
    *                Index n belongs to output n
    * @param queueSize: rclcpp QoS 
+   * 
+   * @throw std::runtime_error if rclcpp is not initialized
+   * @throw eeros::Fault if frames vector size unequal to template N
    */
   Ros2TransformBroadcaster(rclcpp::Node::SharedPtr node,
                            const std::vector<std::pair<std::string, std::string>>& frames_, 
@@ -111,6 +114,8 @@ class Ros2TransformBroadcaster : public Block {
    * 
    * @param index Index has the same function as getInPoseRotation. It belongs to a tf
    * @return the Input
+   * 
+   * @throw eeros::control::IndexOutOfBoundsFault if index >= N
    */
   inline control::Input<math::Vector3>& getInPoseTranslation(const uint8_t index){
     if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
@@ -122,6 +127,8 @@ class Ros2TransformBroadcaster : public Block {
    * 
    * @param index Index has the same function as getInPoseTranslation. It belongs to a tf
    * @return the Input
+   * 
+   * @throw eeros::control::IndexOutOfBoundsFault if index >= N
    */
   inline control::Input<math::Vector3>& getInPoseRotation(const uint8_t index){
     if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 

--- a/includes/eeros/control/ros2/Ros2TransformListener.hpp
+++ b/includes/eeros/control/ros2/Ros2TransformListener.hpp
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <eeros/control/ros2/EerosRosTools.hpp>
+#include <vector>
+#include <mutex>
+
+#include <eeros/control/Block.hpp>
+#include <eeros/control/Input.hpp>
+#include <eeros/logger/Logger.hpp>
+#include <eeros/core/System.hpp>
+#include <eeros/math/Matrix.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class generates the transformation between two frames.
+ * It is recommended to create only one object of this class.
+ * 
+ * @tparam N defines how many tf generated from the tf tree
+ * @tparam N Must fullfill: N == frames.size
+ * 
+ * It generates the transformation as follow:
+ * out[i] => transformation between frames[i].first to frames[i].second
+ */
+template<uint8_t N>
+class Ros2TransformListener: public Block {
+ public:
+
+  /** 
+   * Creates a tf listener for dynamic tf's
+   * 
+   * @param node: a rclcpp node (dosent depend whitch one. Only for Ros clock needed)
+   * @param frames: first element parent second element child frame
+   *                Index n belongs to output n
+   * @param queueSize: rclcpp QoS 
+   */
+  Ros2TransformListener(rclcpp::Node::SharedPtr node,
+                        const std::vector<std::pair<std::string, std::string>>& frames_, 
+                        uint32_t queueSize=1000, 
+                        tf2::Duration bufferCacheTime = tf2::BUFFER_CORE_DEFAULT_CACHE_TIME)
+    : running(false),
+      log(logger::Logger::getLogger('t')),
+      frames(frames_) {
+    static uint8_t objectCount = 0;
+    static std::mutex mtx;
+    if(frames.size() != N){
+        std::ostringstream oss;
+        oss << __FILE__ << "::" << __LINE__ << "\n frames (size: " << frames.size() << ") must have the same length as template param N=" << N;
+        throw eeros::Fault(oss.str());
+    }
+    for(int i = 0; i<N; i++) {
+      lastTime[i] = 0;
+    }
+
+    /* Checker to warn if more than one instance is created */
+    mtx.lock();
+    if(objectCount != 0){
+      log.warn() << "Created multiple instance of class Ros2TransformListener.";
+      log.warn() << " -> It is recommended to create only one instance!!!";
+    }
+    objectCount++;
+    mtx.unlock();
+
+    CHECK_RCLCPP_OK();
+    tf_buffer = std::make_shared<tf2_ros::Buffer>(node->get_clock(), bufferCacheTime);
+    tf_listener = std::make_shared<tf2_ros::TransformListener>(*tf_buffer);
+    log.info() << "Ros tf broadcaster Listener generated on node: " << node->get_name();
+    running = true;
+}
+
+  virtual void run() {
+    if(running) {
+      for(uint8_t i = 0; i<N;i++) {
+        try {
+          msg = tf_buffer->lookupTransform(frames[i].second, frames[i].first, tf2::TimePointZero);
+          qt.setX(msg.transform.rotation.x);
+          qt.setY(msg.transform.rotation.y);
+          qt.setZ(msg.transform.rotation.z);
+          qt.setW(msg.transform.rotation.w);
+          qt.normalize();
+          tf2::Matrix3x3 tfmatrix(qt);
+          tfmatrix.getRPY(poseRotation[0],
+                          poseRotation[1],
+                          poseRotation[2]);
+          this->outPoseRotation[i].getSignal().setValue(poseRotation);
+          this->outPoseRotation[i].getSignal().setTimestamp(System::getTimeNs());
+          poseTranslation[0] = msg.transform.translation.x;
+          poseTranslation[1] = msg.transform.translation.y;
+          poseTranslation[2] = msg.transform.translation.z;
+          this->outPoseTranslation[i].getSignal().setValue(poseTranslation);
+          this->outPoseTranslation[i].getSignal().setTimestamp(System::getTimeNs());          
+        } catch (const tf2::TransformException &e) {
+          if((lastTime[i] + 2000000000) < eeros::System::getTimeNs()){
+            log.warn() << "Couldn't process tf transformation for Frames:'" << frames[i].first <<"' to '" << frames[i].second << "'";
+            log.warn() << "what(): " << e.what();
+            lastTime[i] = eeros::System::getTimeNs();
+          }
+        }
+      }
+    }
+  }
+
+
+  virtual control::Output<math::Vector3>& getOutPoseTranslation(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return outPoseTranslation[index];
+  }
+
+  virtual control::Output<math::Vector3>& getOutPoseRotation(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return outPoseRotation[index];
+  }
+
+ protected:
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer;
+  bool running;
+  eeros::logger::Logger log;
+  const std::vector<std::pair<std::string, std::string>> frames;
+  geometry_msgs::msg::TransformStamped msg;
+
+  uint64_t lastTime[N];
+
+  math::Vector3 poseTranslation;
+  math::Vector3 poseRotation;
+  tf2::Quaternion qt;
+  control::Output<math::Vector3> outPoseTranslation[N];
+  control::Output<math::Vector3> outPoseRotation[N];
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2TransformListener.hpp
+++ b/includes/eeros/control/ros2/Ros2TransformListener.hpp
@@ -42,6 +42,8 @@ class Ros2TransformListener: public Block {
    * @param frames: first element parent second element child frame
    *                Index n belongs to output n
    * @param queueSize: rclcpp QoS 
+   * 
+   * @throw std::runtime_error if rclcpp is not initialized
    */
   Ros2TransformListener(rclcpp::Node::SharedPtr node,
                         const std::vector<std::pair<std::string, std::string>>& frames_, 
@@ -109,12 +111,27 @@ class Ros2TransformListener: public Block {
     }
   }
 
-
+  /**
+   * Get the output for rotation
+   * 
+   * @param index Index has the same function as getOutPoseRotation. It belongs to a tf
+   * @return the Input
+   * 
+   * @throw eeros::control::IndexOutOfBoundsFault if index >= N
+   */
   virtual control::Output<math::Vector3>& getOutPoseTranslation(uint8_t index) {
     if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
     return outPoseTranslation[index];
   }
 
+  /**
+   * Get the output for rotation
+   * 
+   * @param index Index has the same function as getOutPoseTranslation. It belongs to a tf
+   * @return the Input
+   * 
+   * @throw eeros::control::IndexOutOfBoundsFault if index >= N
+   */
   virtual control::Output<math::Vector3>& getOutPoseRotation(uint8_t index) {
     if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
     return outPoseRotation[index];

--- a/includes/eeros/control/ros2/Ros2TypedefHelper.hpp
+++ b/includes/eeros/control/ros2/Ros2TypedefHelper.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace eeros {
+namespace control {
+
+/**
+ * Type to define the plane to which the 2D vector is oriented.
+ */
+typedef enum{
+  PLANE_XY,
+  PLANE_XZ,
+  PLANE_YZ
+}Plane_t;
+
+/**
+ * Type to define the axe to which the double is oriented.
+ */
+typedef enum{
+  AXE_X,
+  AXE_Y,
+  AXE_Z
+}Axe_t;
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2Vector2DTo3D.hpp
+++ b/includes/eeros/control/ros2/Ros2Vector2DTo3D.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <type_traits>
+#include <eeros/control/Blockio.hpp>
+#include <eeros/math/Matrix.hpp>
+#include <eeros/control/Input.hpp>
+#include <eeros/control/Output.hpp>
+
+#include "ros2/Ros2TypedefHelper.hpp"
+
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class is to convert a 2D vector (Alingend in a plane) to a 3D Vector.
+ * Input[i] and output[i] belongs together.
+ * 
+ * @tparam N Defines how many vectors has to be transformed.
+ */
+template<uint8_t N = 1>
+class Ros2Vector2DTo3D : public control::Blockio<0,0> {
+  static_assert(N != 0, "Template parameter N must not be zero");
+ public:
+
+  /**
+   * Special constructor if all vectors are in the same 2D plane 
+   * and the third value has to be filled with the same value by all.
+   * 
+   * @param provPlane: Specifies the plane to which the 2D vector is aligned.
+   * @param valueToFill: Defines the value with which the third dimension must be filled.
+   * @param swap: True if 2D vector has rotated in order (first y the x or first z then y) 
+   */
+  Ros2Vector2DTo3D(const Plane_t provPlane, 
+                   double valueToFill = 0,
+                   bool swap = false)
+    : Ros2Vector2DTo3D(std::vector<Plane_t>(N, provPlane), std::vector<double>(N, valueToFill), swap) {}
+  
+  /**
+   * Special constructor if all vectors are in different 2D planes 
+   * and the third value has to be filled with the same value by all.
+   * 
+   * @param provPlane: Specifies the plane to which the 2D vector is aligned.
+   * @param valueToFill: Defines the value with which the third dimension must be filled.
+   * @param swap: True if 2D vector has rotated in order (first y the x or first z then y) 
+   */
+  Ros2Vector2DTo3D(const std::vector<Plane_t> provPlane, 
+                   double valueToFill = 0,
+                   bool swap = false)
+    : Ros2Vector2DTo3D(provPlane, std::vector<double>(N, valueToFill), swap) {}
+  
+  /**
+   * General constructor if all vectors are in different 2D planes 
+   * and the third value has to be different
+   * 
+   * @param provPlane: Specifies the plane to which the 2D vector is aligned.
+   * @param valueToFill: Defines the value with which the third dimension must be filled.
+   * @param swap: True if 2D vector has rotated in order (first y the x or first z then y) 
+   */
+  Ros2Vector2DTo3D(const std::vector<Plane_t> &provPlane,
+                   const std::vector<double> &valueToFill,
+                   bool swap = false)
+    : provPlane_(provPlane),
+      valueToFill_(valueToFill),
+      swap_(swap) {
+    if(provPlane.size() != N || valueToFill.size() != N){
+      std::ostringstream oss;
+      oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t Provided Planes and valueToFill must have the same size as N (plans size: " << provPlane.size() << ",valueToFill size: " << valueToFill.size() << ", N size: " << std::to_string(N) << ")";
+      throw eeros::Fault(oss.str());
+    }
+  }
+
+  /* switching farbic */
+  void run() override {
+    for(int i = 0; i<N; i++){
+      inTemp = this->in[i].getSignal().getValue();
+      switch(provPlane_[i]){
+        case PLANE_XY:
+          if(swap_){
+            outTemp.set(0,0, inTemp[1]);
+            outTemp.set(1,0, inTemp[0]);
+            outTemp.set(2,0, valueToFill_[i]);
+          } else {
+            outTemp.set(0,0, inTemp[0]);
+            outTemp.set(1,0, inTemp[1]);
+            outTemp.set(2,0, valueToFill_[i]);
+          }
+        break;
+        case PLANE_XZ:
+          if(swap_){
+            outTemp.set(0,0, inTemp[1]);
+            outTemp.set(1,0, valueToFill_[i]);
+            outTemp.set(2,0, inTemp[0]);
+          } else {
+            outTemp.set(0,0, inTemp[0]);
+            outTemp.set(1,0, valueToFill_[i]);
+            outTemp.set(2,0, inTemp[1]);
+          }
+        break;
+        case PLANE_YZ:
+          if(swap_){
+            outTemp.set(0,0, valueToFill_[i]);
+            outTemp.set(1,0, inTemp[1]);
+            outTemp.set(2,0, inTemp[0]);
+          } else {
+            outTemp.set(0,0, valueToFill_[i]);
+            outTemp.set(1,0, inTemp[0]);
+            outTemp.set(2,0, inTemp[1]);
+          }
+        break;
+        default:
+          std::ostringstream oss;
+          oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t In the switch of an enum, the default case is entred. Big Upsii";
+          throw eeros::Fault(oss.str());
+        break;
+      }
+      this->out[i].getSignal().setValue(outTemp);
+      this->out[i].getSignal().setTimestamp(this->in[i].getSignal().getTimestamp());
+    }
+  }
+
+  /**
+   * Get an input of the block.
+   * 
+   * @param index - index of the input
+   * @return input
+   */
+  virtual Input<math::Vector2>& getIn(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return in[index];
+  }
+
+  /**
+   * Get the output of the block.
+   * 
+   * @return output
+   */
+  virtual Output<math::Vector3>& getOut(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of output vector in block '" + this->getName() + "'"); 
+    return out[index];
+  }
+
+ private:
+  const std::vector<Plane_t> provPlane_;
+  const std::vector<double> valueToFill_;
+  const bool swap_;
+  math::Vector2 inTemp;
+  math::Vector3 outTemp;
+
+  Input<math::Vector2> in[N];
+  Output<math::Vector3> out[N];
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2Vector3DTo2D.hpp
+++ b/includes/eeros/control/ros2/Ros2Vector3DTo2D.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <type_traits>
+#include <eeros/control/Blockio.hpp>
+#include <eeros/math/Matrix.hpp>
+#include "ros2/Ros2TypedefHelper.hpp"
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class is to convert a 3D vector to a 2D Vector (Alingend in a plane).
+ * Input[i] and output[i] belongs together.
+ * 
+ * @tparam N Defines how many vectors has to be transformed.
+ */
+template<uint8_t N = 1>
+class Ros2Vector3DTo2D : public control::Blockio<0,0> {
+ public:
+ 
+  /**
+   * Special constructor if all vectors are in the same 2D plane 
+   * 
+   * @param provPlane: Specifies the plane to which the 2D vector is aligned.
+   * @param swap: True if 2D vector has rotated in order (first y the x or first z then y) 
+   */
+  Ros2Vector3DTo2D(const Plane_t reqPlane, 
+                   bool swap = false)
+    : Ros2Vector3DTo2D(std::vector<Plane_t>(N, reqPlane), std::vector<bool>(N, swap)) {}
+  
+  /**
+   * General constructor if all vectors are in different 2D planes 
+   * 
+   * @param provPlane: Specifies the plane to which the 2D vector is aligned.
+   * @param swap: True if 2D vector has rotated in order (first y the x or first z then y) 
+   */
+  Ros2Vector3DTo2D(const std::vector<Plane_t> &reqPlane,
+                   const std::vector<bool> &swap = false)
+    : reqPlane_(reqPlane),
+      swap_(swap) {
+    if(reqPlane.size() != N){
+      std::ostringstream oss;
+      oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t Provided Planes and swap must have the same size as N (plans size: " << reqPlane.size() << ",swap size: " << swap.size() << ", N size: " << std::to_string(N) << ")";
+      throw eeros::Fault(oss.str());
+    }
+  }
+
+  /* switching farbic */
+  void run() override {
+    for(int i = 0; i<N; i++){
+      inTemp = this->in[i].getSignal().getValue();
+      switch(reqPlane_[i]){
+        case PLANE_XY:
+          if(swap_[i]){
+            outTemp.set(0,0, inTemp[1]);
+            outTemp.set(1,0, inTemp[0]);
+          } else {
+            outTemp.set(0,0, inTemp[0]);
+            outTemp.set(1,0, inTemp[1]);
+          }
+        break;
+        case PLANE_XZ:
+          if(swap_[i]){
+            outTemp.set(0,0, inTemp[2]);
+            outTemp.set(1,0, inTemp[0]);
+          } else {
+            outTemp.set(0,0, inTemp[0]);
+            outTemp.set(1,0, inTemp[2]);
+          }
+        break;
+        case PLANE_YZ:
+          if(swap_[i]){
+            outTemp.set(0,0, inTemp[2]);
+            outTemp.set(1,0, inTemp[1]);
+          } else {
+            outTemp.set(0,0, inTemp[1]);
+            outTemp.set(1,0, inTemp[2]);
+          }
+        break;
+        default:
+          std::ostringstream oss;
+          oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t In the switch of an enum, the default case is entred. Big Upsii";
+          throw eeros::Fault(oss.str());
+        break;
+      }
+      this->out[i].getSignal().setValue(outTemp);
+      this->out[i].getSignal().setTimestamp(this->in[i].getSignal().getTimestamp());
+    }
+  }
+
+  /**
+   * Get an input of the block.
+   * 
+   * @param index - index of the input
+   * @return input
+   */
+  virtual Input<math::Vector3>& getIn(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return in[index];
+  }
+
+  /**
+   * Get the output of the block.
+   * 
+   * @return output
+   */
+  virtual Output<math::Vector2>& getOut(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of output vector in block '" + this->getName() + "'"); 
+    return out[index];
+  }
+
+ private:
+  const std::vector<Plane_t> reqPlane_;
+  const std::vector<bool> swap_;
+  math::Vector3 inTemp;
+  math::Vector2 outTemp;
+
+  Input<math::Vector3> in[N];
+  Output<math::Vector2> out[N];
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/Ros2Vector3DToDouble.hpp
+++ b/includes/eeros/control/ros2/Ros2Vector3DToDouble.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <type_traits>
+#include <eeros/control/Blockio.hpp>
+#include <eeros/math/Matrix.hpp>
+#include "ros2/Ros2TypedefHelper.hpp"
+
+namespace eeros {
+namespace control {
+
+#pragma message("WARNING: You are using an experimental class that has not been fully tested: " __FILE__)
+
+/**
+ * This class is to convert a 3D Vector to a double (Alingend in a axe).
+ * Input[i] and output[i] belongs together.
+ * 
+ * @tparam N Defines how many vectors has to be transformed.
+ */
+template<uint8_t N = 1>
+class Ros2Vector3DToDouble : public control::Blockio<0,0> {
+ public:
+ 
+  /**
+   * Special constructor if all doubles are in the same axe
+   * and the other value has to be filled with the same value by all.
+   * 
+   * @param reqAxe_: Specifies the axe to which the value is aligned.
+   * @param valueToFill: Defines the value with which the third dimension must be filled.
+   */
+  Ros2Vector3DToDouble(Axe_t reqAxe)
+    : Ros2Vector3DToDouble(std::vector<Axe_t>(N, reqAxe)) {}
+    
+  /**
+   * General constructor if all doubles are in different 2D planes 
+   * and the third value has to be different
+   * 
+   * @param reqAxe_: Specifies the axe to which the value is aligned.
+   * @param valueToFill: Defines the value with which the other dimension must be filled.
+   */
+  Ros2Vector3DToDouble(const std::vector<Axe_t> &reqAxe)
+    : reqAxe_(reqAxe) {
+    if(reqAxe_.size() != N){
+      std::ostringstream oss;
+      oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t provided Axe must have the same size as N (axe size: " << reqAxe_.size() << ", N size: " << std::to_string(N) << ")";
+      throw eeros::Fault(oss.str());
+    }
+  }
+
+  /* switching farbic */
+  void run() override {
+    for(int i = 0; i<N; i++){
+      inTemp = this->in[i].getSignal().getValue();
+      switch(reqAxe_[i]){
+        case AXE_X:
+          outTemp = inTemp[0];
+        break;
+        case AXE_Y:
+          outTemp = inTemp[1];
+        break;
+        case AXE_Z:
+          outTemp = inTemp[2];
+        break;
+        default:
+          std::ostringstream oss;
+          oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t In the switch of an enum, the default case is entred. Big Upsii";
+          throw eeros::Fault(oss.str());
+        break;
+      }
+      this->out[i].getSignal().setValue(outTemp);
+      this->out[i].getSignal().setTimestamp(this->in[i].getSignal().getTimestamp());
+    }
+  }
+
+  /**
+   * Get an input of the block.
+   * 
+   * @param index - index of the input
+   * @return input
+   */
+  virtual Input<math::Vector3>& getIn(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of input vector in block '" + this->getName() + "'"); 
+    return in[index];
+  }
+
+  /**
+   * Get the output of the block.
+   * 
+   * @return output
+   */
+  virtual Output<double>& getOut(uint8_t index) {
+    if (index >= N) throw IndexOutOfBoundsFault("Trying to get inexistent element of output vector in block '" + this->getName() + "'"); 
+    return out[index];
+  }
+
+ private:
+  const std::vector<Axe_t> reqAxe_;
+  double outTemp;
+  math::Vector3 inTemp;
+
+  Input<math::Vector3> in[N];
+  Output<double> out[N];
+};
+
+} /* END Namespace: control */
+} /* END Namespace: eeros */

--- a/includes/eeros/control/ros2/RosPublisherDouble.hpp
+++ b/includes/eeros/control/ros2/RosPublisherDouble.hpp
@@ -12,6 +12,8 @@ namespace control {
  * publishes it as a ROS message of type std_msgs::msg::Float64.
  * 
  * @since v1.0
+ *
+ * @deprecated Since Foxy
  */
 class RosPublisherDouble : public RosPublisher<std_msgs::msg::Float64, double> {
   typedef std_msgs::msg::Float64 TRosMsg;

--- a/includes/eeros/control/ros2/RosPublisherDoubleArray.hpp
+++ b/includes/eeros/control/ros2/RosPublisherDoubleArray.hpp
@@ -14,6 +14,8 @@ namespace control {
  * 
  * @tparam SigInType - type of the input signal
  * @since v1.0
+ *
+ * @deprecated Since Foxy
  */
 template < typename SigInType >
 class RosPublisherDoubleArray : public RosPublisher<std_msgs::msg::Float64MultiArray, SigInType> {

--- a/includes/eeros/control/ros2/RosPublisherSafetyLevelName.hpp
+++ b/includes/eeros/control/ros2/RosPublisherSafetyLevelName.hpp
@@ -2,6 +2,7 @@
 
 #include <eeros/control/ros2/RosPublisher.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <memory>
 #include <eeros/safety/SafetySystem.hpp>
 
 using namespace eeros::safety;
@@ -38,8 +39,8 @@ class RosPublisherSafetyLevelName : public RosPublisher<std_msgs::msg::String, d
    * 
    * @param ss - safety system
    */
-  void setSafetySystem(SafetySystem& ss) {
-    safetySystem = &ss;
+  void setSafetySystem(std::shared_ptr<SafetySystem> ss) {
+    safetySystem = ss;
   }
 
   /**
@@ -55,7 +56,7 @@ class RosPublisherSafetyLevelName : public RosPublisher<std_msgs::msg::String, d
   }
   
  private:
-  SafetySystem* safetySystem;
+  std::shared_ptr<SafetySystem> safetySystem;
 };
 
 } /* End namespace: control */

--- a/includes/eeros/control/ros2/RosPublisherSafetyLevelName.hpp
+++ b/includes/eeros/control/ros2/RosPublisherSafetyLevelName.hpp
@@ -1,5 +1,4 @@
-#ifndef ORG_EEROS_CONTROL_ROSPUBLISHER_SAFETYLEVEL_HPP_
-#define ORG_EEROS_CONTROL_ROSPUBLISHER_SAFETYLEVEL_HPP_
+#pragma once
 
 #include <eeros/control/ros2/RosPublisher.hpp>
 #include <std_msgs/msg/string.hpp>
@@ -12,9 +11,7 @@ namespace control {
 
 /**
  * This block allows to read the safety level of the safety system and
- * publish it as a ROS message of type std_msgs::msg::UInt32.
- * 
- * @since v1.0
+ * publish it as a ROS message of type std_msgs::msg::String.
  */
 class RosPublisherSafetyLevelName : public RosPublisher<std_msgs::msg::String, double> {
   typedef std_msgs::msg::String TRosMsg;
@@ -61,7 +58,5 @@ class RosPublisherSafetyLevelName : public RosPublisher<std_msgs::msg::String, d
   SafetySystem* safetySystem;
 };
 
-}
-}
-
-#endif /* ORG_EEROS_CONTROL_ROSPUBLISHER_SAFETYLEVEL_HPP_ */
+} /* End namespace: control */
+} /* End namespace: eeros */

--- a/includes/eeros/control/ros2/RosPublisherSafetyLevelName.hpp
+++ b/includes/eeros/control/ros2/RosPublisherSafetyLevelName.hpp
@@ -1,0 +1,67 @@
+#ifndef ORG_EEROS_CONTROL_ROSPUBLISHER_SAFETYLEVEL_HPP_
+#define ORG_EEROS_CONTROL_ROSPUBLISHER_SAFETYLEVEL_HPP_
+
+#include <eeros/control/ros2/RosPublisher.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <eeros/safety/SafetySystem.hpp>
+
+using namespace eeros::safety;
+
+namespace eeros {
+namespace control {
+
+/**
+ * This block allows to read the safety level of the safety system and
+ * publish it as a ROS message of type std_msgs::msg::UInt32.
+ * 
+ * @since v1.0
+ */
+class RosPublisherSafetyLevelName : public RosPublisher<std_msgs::msg::String, double> {
+  typedef std_msgs::msg::String TRosMsg;
+  
+ public:
+  /**
+   * Creates an instance of a publisher block which publishes the safety level.
+   * 
+   * @param node - ROS node as a shared ptr
+   * @param topic - name of the topic
+   * @param queueSize - maximum number of outgoing messages to be queued for delivery to subscribers
+   */ 
+  RosPublisherSafetyLevelName(const rclcpp::Node::SharedPtr node, const std::string& topic, const uint32_t queueSize=1000)
+      : RosPublisher<TRosMsg, double>(node, topic, queueSize) { }
+  
+  /**
+   * Disabling use of copy constructor because the block should never be copied unintentionally.
+   */
+  RosPublisherSafetyLevelName(const RosPublisherSafetyLevelName& other) = delete;
+
+  /**
+   * Stores a reference to the safety system. Call this function after creating the 
+   * control system and the safety system.
+   * 
+   * @param ss - safety system
+   */
+  void setSafetySystem(SafetySystem& ss) {
+    safetySystem = &ss;
+  }
+
+  /**
+   * Sets the message to be published by this block.
+   *
+   * @param msg - message content
+   */
+  virtual void setRosMsg(TRosMsg& msg) {
+    if (safetySystem != nullptr) {
+      SafetyLevel sl = safetySystem->getCurrentLevel();
+      msg.data = sl.getDescription();
+    }
+  }
+  
+ private:
+  SafetySystem* safetySystem;
+};
+
+}
+}
+
+#endif /* ORG_EEROS_CONTROL_ROSPUBLISHER_SAFETYLEVEL_HPP_ */

--- a/includes/eeros/control/ros2/RosSubscriberDouble.hpp
+++ b/includes/eeros/control/ros2/RosSubscriberDouble.hpp
@@ -13,6 +13,8 @@ namespace control {
  * and publishes it as a signal of type double.
  * 
  * @since v1.0
+ *
+ * @deprecated Since Foxy
  */
 class RosSubscriberDouble : public RosSubscriber<std_msgs::msg::Float64, double> {
   typedef std_msgs::msg::Float64 TRosMsg;

--- a/includes/eeros/control/ros2/RosSubscriberDoubleArray.hpp
+++ b/includes/eeros/control/ros2/RosSubscriberDoubleArray.hpp
@@ -14,6 +14,8 @@ namespace control {
  * 
  * @tparam SigOutType - type of the output signal
  * @since v1.0
+ *
+ * @deprecated Since Foxy
  */
 template < typename SigOutType >
 class RosSubscriberDoubleArray : public RosSubscriber<std_msgs::msg::Float64MultiArray, SigOutType> {

--- a/includes/eeros/core/ObjectManager.hpp
+++ b/includes/eeros/core/ObjectManager.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <any>
+#include <eeros/logger/Logger.hpp>
+
+/**
+ * This Class is to centralize the object management
+ * 
+ * When using this class, make sure that all objects are not raw pointers.
+ * Use shared pointers for all objects managed by this class.
+ * 
+ * This class holds all objects (as shared pointer<std::any>)
+ * Each stored object is associated with a key.
+ * This key must be used to retrieve the object.
+*/
+class ObjectManager {
+public:
+  // Singleton
+  static ObjectManager* getInstance() {
+    static ObjectManager* instance = new ObjectManager();
+    return instance;
+  }
+
+  ObjectManager(ObjectManager&&) = delete;
+  ObjectManager(const ObjectManager&) = delete;
+  ObjectManager& operator=(ObjectManager&&) = delete;
+  ObjectManager& operator=(const ObjectManager&) = delete;
+
+  /**
+   * @brief Gets an object from the Manager wich is store by the key
+   * 
+   * @warning This function is expensive. Do not call this function outside from the init.
+   * Especialy not in run methodes or similar.
+   * 
+   * @param key The key for the requested object.
+   * @return the object witch belongs to the key.
+   * 
+   * @throw std::bad_any_cast is thrown if template is not the same as the stored type.
+   * @throw std::runtime_error is thrown if key is not in the list.
+  */
+  template<typename T>
+  std::shared_ptr<T> get(const std::string& key) {
+    auto it = objects.find(key);
+    if (it != objects.end()) {
+      try {
+        std::shared_ptr<T> storedPtr = std::any_cast<std::shared_ptr<T>>(*(it->second));
+        return storedPtr;
+      } catch (const std::bad_any_cast& e) {
+        log.error() << "Failed to cast: " << e.what();
+        /* Pass it to the global abort method, or let the user catch it. */
+        throw e;
+      }
+    }
+    std::ostringstream oss;
+    oss << __FILE__ << "::" << __LINE__ << "\n\t\t\t\t\t ObjectManager: Key \"" << key << "\" not found inside the object list.";
+    throw std::runtime_error(oss.str());
+  }
+
+  /**
+   * Sets an object to the Manager which is store by the key
+   * 
+   * @param key The key to store the object
+   * @param obj The object to store
+  */
+  template<typename T>
+  void add(const std::string& key, std::shared_ptr<T> smartPtr) {
+    if(objects.count(key)) {
+      log.fatal() << "ObjectManager: Key: \"" << key << "\" already exists inside the list.";
+    }
+    objects[key] = std::make_shared<std::any>(smartPtr);
+  }
+
+  /**
+   * @see addObject(const std::string&, std::shared_ptr<T>)
+  */
+  template<typename T>
+  void add(const std::string& key, T* obj) {
+    std::shared_ptr<T> smartPtr(obj);
+    add(key, smartPtr);
+  }
+
+  /**
+   * @brief Get the number of stored objects
+   * @return nof Objects
+  */
+  size_t nofObjects(){return objects.size();}
+
+  /**
+   * @brief Givs a list of all keys back
+   * @return List of all keys
+  */
+  std::vector<std::string> storedKeys() {
+    std::vector<std::string> keys;
+    keys.reserve(objects.size());
+    for (const auto& pair : objects) {
+        keys.push_back(pair.first);
+    }
+    return keys;
+  }
+
+private:
+  ObjectManager() = default;
+
+  std::unordered_map<std::string, std::shared_ptr<std::any>> objects;
+  eeros::logger::Logger log = eeros::logger::Logger::getLogger('O');
+};

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -12,3 +12,7 @@ add_eeros_sources(
 if(LINUX)
 	add_eeros_sources(XBoxInput.cpp MouseInput.cpp SpaceNavigatorInput.cpp)
 endif()
+
+if(USE_ROS2)
+  add_subdirectory(ros2)
+endif()

--- a/src/control/ros2/CMakeLists.txt
+++ b/src/control/ros2/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_eeros_sources(
+  EerosRosTools.cpp
+)
+

--- a/src/control/ros2/EerosRosTools.cpp
+++ b/src/control/ros2/EerosRosTools.cpp
@@ -1,0 +1,12 @@
+#include <eeros/control/ros2/EerosRosTools.hpp>
+
+namespace eeros {
+namespace control {
+namespace rosTools {
+
+void (*EerosRos2Tools::customHandler)(int) = nullptr;
+void (*EerosRos2Tools::ros2Handler)(int) = nullptr;
+
+} /* End Namespace: rosTools */
+} /* End Namespace: control */
+} /* End Namespace: eeros */


### PR DESCRIPTION
### Added classes
- Vector transitions double->3D, 2D->3D and inverse 
- Publisher odometry for Nav2
- Tf management classes (tf Broadcaster, tf Static Broadcaster, tf Listener)
- Subscriber for Twist topics
- Publisher to publish safety level name as string
- Object manager (can store any object as shared ptr)
  With this manager it is recommended to use shared ptr only, not raw ptr
- EerosRos2Tools static only class for initialization, node creation and SIGINT handling of Ros2 along Eeros.

### Added functionality
- in class control/Constant.hpp and control/Signal.hpp
  for enum compatibility.

### Deprecated
- all static functions in control/EerosRosTools.hpp
  Functions moved to new (static only) class EerosRos2Tools.hpp for better encapsulation
- Class RosPublisherDouble, RosPublisherDoubleArray, RosSubscriberDouble, RosSubscriberDoubleArray.
  due to ros2 package std_msgs is marked as deprecated since foxy

### Bug fixes
- In class control/I.hpp
  Fixed problem with initial min init value not being the real min of the datatype.